### PR TITLE
Implement peripheral-specific configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-02-09 deimos 0.6.1
+
+### Added
+
+* Add methods for parsing and emitting configuration packets to Peripheral
+    * Default impl matches existing system, but allows future peripherals with additional config fields
+
 ## 2025-02-05 deimos 0.6.0
 
 ### Added

--- a/software/deimos/Cargo.toml
+++ b/software/deimos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deimos"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Deimos Controls LLC <support@deimoscontrols.com>"]
 license = "0BSD OR Apache-2.0"
@@ -13,7 +13,7 @@ readme = "./README.md"
 
 [dependencies]
 deimos_shared = { path = "../deimos_shared", version = "0.3.0" }
-flaw = "0.2.3"
+flaw = "0.2.4"
 
 # Control loop prep
 chrono = { version = "0.4.39", features = ["std"], default-features = false }  # timestamp formatting

--- a/software/deimos/src/controller/mod.rs
+++ b/software/deimos/src/controller/mod.rs
@@ -461,7 +461,7 @@ impl Controller {
                                     println!(
                                             "Received malformed configuration response from peripheral {pid:?} on socket {sid}"
                                         );
-                                        continue
+                                    continue;
                                 }
                                 let ack = ConfiguringOutput::read_bytes(buf);
                                 let addr = (sid, pid);

--- a/software/deimos/src/controller/mod.rs
+++ b/software/deimos/src/controller/mod.rs
@@ -410,7 +410,7 @@ impl Controller {
             while self.sockets.iter_mut().any(|sock| sock.recv().is_some()) {}
 
             // Bind
-            let _bound_peripherals = self.bind(
+            let bound_peripherals = self.bind(
                 Some(&addresses),
                 // None,
                 self.ctx.binding_timeout_ms,
@@ -431,10 +431,13 @@ impl Controller {
                 loss_of_contact_limit: self.ctx.peripheral_loss_of_contact_limit,
                 mode: Mode::Roundtrip,
             };
-            let num_to_write = ConfiguringInput::BYTE_LEN;
-            config_input.write_bytes(&mut txbuf[..num_to_write]);
+            // let num_to_write = ConfiguringInput::BYTE_LEN;
+            // config_input.write_bytes(&mut txbuf[..num_to_write]);
 
             for (sid, pid) in addresses.iter() {
+                let p = bound_peripherals.get(&(*sid, *pid)).unwrap();
+                let num_to_write = p.configuring_input_size();
+                p.emit_configuring(config_input, &mut txbuf[..num_to_write]);
                 self.sockets[*sid]
                     .send(*pid, &txbuf[..num_to_write])
                     .unwrap();
@@ -448,10 +451,18 @@ impl Controller {
                 for (sid, socket) in self.sockets.iter_mut().enumerate() {
                     if let Some((pid, _rxtime, buf)) = socket.recv() {
                         let amt = buf.len();
+
                         // Make sure the packet is the right size and the peripheral ID is recognized
-                        match (pid, amt) {
-                            (Some(pid), ConfiguringOutput::BYTE_LEN) => {
+                        match pid {
+                            Some(pid) => {
                                 // Parse the (potential) peripheral's response
+                                let p = bound_peripherals.get(&(sid, pid)).unwrap();
+                                if amt != p.configuring_output_size() {
+                                    println!(
+                                            "Received malformed configuration response from peripheral {pid:?} on socket {sid}"
+                                        );
+                                        continue
+                                }
                                 let ack = ConfiguringOutput::read_bytes(buf);
                                 let addr = (sid, pid);
 
@@ -477,9 +488,7 @@ impl Controller {
                                 }
                             }
                             _ => {
-                                println!(
-                                    "Received malformed configuration response from socket {sid}"
-                                )
+                                println!("Received response from peripheral not in address table")
                             }
                         }
                     }

--- a/software/deimos/src/dispatcher/mod.rs
+++ b/software/deimos/src/dispatcher/mod.rs
@@ -69,17 +69,8 @@ pub fn header_columns(channel_names: &[String]) -> Vec<String> {
 
 /// Generate CSV header row given some channel names
 pub fn csv_header(channel_names: &[String]) -> String {
-    let cols = header_columns(channel_names);
-    let mut header_string = String::new();
-    let n = cols.len();
-    for (i, c) in cols.iter().enumerate() {
-        header_string.push_str(c);
-        if i < n - 1 {
-            header_string.push(',');
-        } else {
-            header_string.push('\n');
-        }
-    }
+    let mut header_string = header_columns(channel_names).join(",");
+    header_string.push_str("\n");
     header_string
 }
 

--- a/software/deimos/src/dispatcher/mod.rs
+++ b/software/deimos/src/dispatcher/mod.rs
@@ -70,7 +70,7 @@ pub fn header_columns(channel_names: &[String]) -> Vec<String> {
 /// Generate CSV header row given some channel names
 pub fn csv_header(channel_names: &[String]) -> String {
     let mut header_string = header_columns(channel_names).join(",");
-    header_string.push_str("\n");
+    header_string.push('\n');
     header_string
 }
 

--- a/software/deimos/src/peripheral/mod.rs
+++ b/software/deimos/src/peripheral/mod.rs
@@ -80,11 +80,7 @@ pub trait Peripheral: Send + Sync + Debug {
     }
 
     /// Generate bytes for a packet to send to the peripheral based on some input values
-    fn emit_configuring(
-        &self,
-        base_config: ConfiguringInput,
-        bytes: &mut [u8],
-    ) {
+    fn emit_configuring(&self, base_config: ConfiguringInput, bytes: &mut [u8]) {
         let num_to_write = self.configuring_input_size();
         base_config.write_bytes(&mut bytes[..num_to_write]);
     }
@@ -94,7 +90,7 @@ pub trait Peripheral: Send + Sync + Debug {
         let resp = ConfiguringOutput::read_bytes(bytes);
         match resp.acknowledge {
             AcknowledgeConfiguration::Ack => Ok(()),
-            x => Err(format!("{x:?}"))
+            x => Err(format!("{x:?}")),
         }
     }
 


### PR DESCRIPTION
## 2025-02-09 deimos 0.6.1

### Added

* Add methods for parsing and emitting configuration packets to Peripheral
    * Default impl matches existing system, but allows future peripherals with additional config fields