### PR TITLE
Reduce compile-time feature configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2025-06-21 deimos 0.10.0, deimos_gui 0.1.1
+
+### Changed
+
+* Refactor to eliminate all conditional compilation features from control program
+  * All features now enabled by default
+* Remove polars dep due to excessive build time
+* Refactor dataframe dispatcher module to use a lightweight internal dataframe target instead of a polars dataframe
+* Update gui dep on control program to not reference features that no longer exist
+
+### Added
+
 ## 2025-06-21 analog_i_rev4 firmware 0.2.0
 
 ### Added

--- a/software/deimos/Cargo.toml
+++ b/software/deimos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deimos"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Deimos Controls LLC <support@deimoscontrols.com>"]
 license = "MIT OR Apache-2.0"
@@ -19,47 +19,34 @@ deimos_shared = { path = "../deimos_shared", version = "0.4.0" }
 
 # Control loop prep
 chrono = { version = "0.4.39", features = ["std"], default-features = false }  # timestamp formatting
-core_affinity = { version = "0.8.1", optional = true }
-thread-priority = {version = "1.2.0", optional = true }
+core_affinity = "0.8.1"
+thread-priority = "2.1.0"
 
 # Calcs
-flaw = "0.2.4"
+flaw = "0.2.5"
 interpn = { version = "0.4.5", default-features = false }
 once_cell = "1.20.2"
 
 # Sideloading support
-crossbeam = { version = "0.8.4", optional = true }
+crossbeam = "0.8.4"
 
 # Serialization
 # Loose versioning enables plugins without multiple crate versions per build
-serde = { version = "^1", features = ["derive", "rc"], optional = true }
-typetag = { version = "^0.2", optional = true }
-serde_json = { version = "^1", features = ["preserve_order"], optional = true }
+serde = { version = "^1", features = ["derive", "rc"] }
+typetag = "^0.2"
+serde_json = { version = "^1", features = ["preserve_order"] }
 
-# Dataframe dispatcher
-polars = { version = "0.46.0", optional = true, features = ["fmt"], default-features = false }
-
-# Timescale DB interface
-postgres = { version = "0.19.9", optional = true }
-postgres-types = { version = "0.2.8", optional = true }
+# Timescale DB / Postgres interface
+postgres = "0.19.10"
+postgres-types = "0.2.9"
 
 [features]
-default = ["ser"]
-all = ["ser", "tsdb", "df", "affinity", "sideloading"]
-tsdb = ["postgres", "postgres-types"]
-df = ["polars"]
-ser = ["serde", "typetag", "serde_json"]
-affinity = ["core_affinity", "thread-priority"]
-sideloading = ["crossbeam"]
 
 [[example]]
 name = "multi_daq"
-required-features = ["tsdb", "ser"]
 
 [[example]]
 name = "ipc_plugin"
-required-features = ["df"]
 
 [[example]]
 name = "sideloading"
-required-features = ["sideloading"]

--- a/software/deimos/examples/ipc_plugin.rs
+++ b/software/deimos/examples/ipc_plugin.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::BTreeMap,
     os::unix::net,
-    sync::{Arc, RwLock},
+    // sync::{Arc, RwLock},
     thread::{self, JoinHandle},
     time::{Duration, Instant, SystemTime},
 };
@@ -32,16 +32,15 @@ use deimos_shared::{
         BindingInput, BindingOutput, ByteStruct, ByteStructLen, ConfiguringInput, ConfiguringOutput,
     },
 };
-use polars::frame::DataFrame;
+// use polars::frame::DataFrame;
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 // For using the controller
 use deimos::{
     calc::Calc,
     controller::context::{ControllerCtx, Termination},
-    dispatcher::{DataFrameDispatcher, Overflow, fmt_time},
+    dispatcher::fmt_time,
     peripheral::{Peripheral, PluginMap},
     socket::unix::UnixSocket,
     *,
@@ -70,13 +69,13 @@ fn main() {
     controller.add_socket(Box::new(UnixSocket::new("ipc_ex")));
 
     // Add an in-memory data target
-    let df_handle = Arc::new(RwLock::new(DataFrame::empty()));
-    let df_dispatcher = Box::new(DataFrameDispatcher::new(
-        df_handle.clone(),
-        1,
-        Overflow::Error,
-    ));
-    controller.add_dispatcher(df_dispatcher);
+    // let df_handle = Arc::new(RwLock::new(DataFrame::empty()));
+    // let df_dispatcher = Box::new(DataFrameDispatcher::new(
+    //     df_handle.clone(),
+    //     1,
+    //     Overflow::Error,
+    // ));
+    // controller.add_dispatcher(df_dispatcher);
 
     // Register the mockup as a plugin
     let mut pmap: PluginMap = BTreeMap::new();
@@ -112,7 +111,6 @@ fn main() {
     println!("Scan found:\n{:?}", scan_result.values());
 
     // Serialize and deserialize the controller (for demonstration purposes)
-    #[cfg(feature = "ser")]
     {
         let serialized_controller = serde_json::to_string_pretty(&controller).unwrap();
         let _: Controller = serde_json::from_str(&serialized_controller).unwrap();
@@ -126,8 +124,8 @@ fn main() {
     mockup_thread.join().unwrap();
 
     // Get collected dataframe
-    let df = df_handle.try_read().unwrap();
-    println!("Collected data: \n{}", df);
+    // let df = df_handle.try_read().unwrap();
+    // println!("Collected data: \n{}", df);
 
     // Clear sockets
     let _ = std::fs::remove_dir_all("./sock");
@@ -135,13 +133,12 @@ fn main() {
 
 /// The controller's representation of the in-memory peripheral mockup,
 /// reusing the AnalogIRev3's packet formats for convenience.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct IpcMockup {
     pub serial_number: u64,
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Peripheral for IpcMockup {
     fn id(&self) -> PeripheralId {
         PeripheralId {

--- a/software/deimos/examples/sideloading.rs
+++ b/software/deimos/examples/sideloading.rs
@@ -13,7 +13,6 @@ use deimos::{
     dispatcher::fmt_time,
 };
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 use std::{
@@ -58,7 +57,6 @@ fn main() {
     );
 
     // Serialize and deserialize the controller (for demonstration purposes)
-    #[cfg(feature = "ser")]
     {
         let serialized_controller = serde_json::to_string_pretty(&controller).unwrap();
         let _: Controller = serde_json::from_str(&serialized_controller).unwrap();
@@ -69,20 +67,19 @@ fn main() {
 }
 
 /// A dummy calc that calls out the time on a channel each cycle
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Speaker {
     // User inputs
     channel_name: String,
     save_outputs: bool,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     endpoint: Endpoint,
 
     prefix: String,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -102,7 +99,7 @@ impl Speaker {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Speaker {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, ctx: ControllerCtx, _input_indices: Vec<usize>, output_range: Range<usize>) {
@@ -146,19 +143,18 @@ impl Calc for Speaker {
 }
 
 /// A dummy calc that receives time from a listener and prints it to the terminal
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Listener {
     // User inputs
     // input_name: String,
     channel_name: String,
     save_outputs: bool,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     endpoint: Endpoint,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -178,7 +174,7 @@ impl Listener {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Listener {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, ctx: ControllerCtx, _input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/affine.rs
+++ b/software/deimos/src/calc/affine.rs
@@ -4,8 +4,7 @@ use super::*;
 use crate::{calc_config, calc_input_names, calc_output_names};
 
 /// A slope and offset, y = ax + b
-#[derive(Default, Debug)]
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Affine {
     // User inputs
     input_name: String,
@@ -14,10 +13,10 @@ pub struct Affine {
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     input_index: usize,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -40,7 +39,7 @@ impl Affine {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Affine {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, _: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/constant.rs
+++ b/software/deimos/src/calc/constant.rs
@@ -4,15 +4,14 @@ use super::*;
 use crate::{calc_config, calc_input_names, calc_output_names};
 
 /// Simplest calc that does anything at all
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Constant {
     // User inputs
     y: f64,
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -29,7 +28,7 @@ impl Constant {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Constant {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, _: ControllerCtx, _: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/inverse_affine.rs
+++ b/software/deimos/src/calc/inverse_affine.rs
@@ -6,8 +6,7 @@ use crate::{calc_config, calc_input_names, calc_output_names};
 /// Derive input voltage from linear amplifier reading
 ///
 /// First subtracts the output offset, then divides by the slope.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct InverseAffine {
     // User inputs
     input_name: String,
@@ -16,10 +15,10 @@ pub struct InverseAffine {
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     input_index: usize,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -42,7 +41,7 @@ impl InverseAffine {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for InverseAffine {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, _: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/mod.rs
+++ b/software/deimos/src/calc/mod.rs
@@ -8,8 +8,6 @@ use std::iter::Iterator;
 use std::{collections::BTreeMap, ops::Range};
 
 use once_cell::sync::Lazy;
-
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 mod orchestrator;
@@ -90,7 +88,6 @@ pub static PROTOTYPES: Lazy<BTreeMap<String, Box<dyn Calc>>> = Lazy::new(|| {
 /// Clone isn't inherently object-safe, so to be able to clone dyn trait objects,
 /// we send it for a loop through the serde typetag system, which provides an
 /// automatically-assembled vtable to determine the downcasted type and clone into it.
-#[cfg(feature = "ser")]
 impl Clone for Box<dyn Calc> {
     fn clone(&self) -> Box<dyn Calc> {
         let new: Box<dyn Calc> =
@@ -101,7 +98,7 @@ impl Clone for Box<dyn Calc> {
 
 /// A calculation that takes some inputs and produces some outputs
 /// at each timestep, and may have some persistent internal state.
-#[cfg_attr(feature = "ser", typetag::serde(tag = "type"))]
+#[typetag::serde(tag = "type")]
 pub trait Calc: Send + Sync + Debug {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, ctx: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>);

--- a/software/deimos/src/calc/orchestrator.rs
+++ b/software/deimos/src/calc/orchestrator.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 use std::iter::Iterator;
 use std::{collections::BTreeMap, ops::Range};
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 use crate::ControllerCtx;
@@ -55,13 +54,12 @@ struct OrchestratorState {
 /// evaluation order. During init, each calc is provided with the indices of the tape
 /// where its inputs and outputs will be placed. During evaluation, each calc is responsible
 /// for using those indices to read its inputs and write its outputs.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct Orchestrator {
     calcs: BTreeMap<CalcName, Box<dyn Calc>>,
     peripheral_input_sources: BTreeMap<PeripheralInputName, FieldName>,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     state: OrchestratorState,
 }
 

--- a/software/deimos/src/calc/pid.rs
+++ b/software/deimos/src/calc/pid.rs
@@ -4,8 +4,7 @@ use super::*;
 use crate::{calc_config, calc_input_names, calc_output_names};
 
 /// A PID controller with simple saturation for anti-windup
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Pid {
     // User inputs
     measurement_name: String,
@@ -23,10 +22,10 @@ pub struct Pid {
     // Values provided by calc orchestrator during init
     dt_s: f64,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     input_indices: Vec<usize>,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -68,7 +67,7 @@ impl Pid {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Pid {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, ctx: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/rtd_pt100.rs
+++ b/software/deimos/src/calc/rtd_pt100.rs
@@ -29,18 +29,17 @@ pub static INTERPOLATOR: Lazy<MulticubicRegular<'static, f64, 1>> = Lazy::new(||
 });
 
 /// Derive input voltage from amplifier output
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct RtdPt100 {
     // User inputs
     resistance_name: String,
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     input_index: usize,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -61,7 +60,7 @@ impl RtdPt100 {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for RtdPt100 {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, _: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/sin.rs
+++ b/software/deimos/src/calc/sin.rs
@@ -6,8 +6,7 @@ use super::*;
 use crate::{calc_config, calc_input_names, calc_output_names};
 
 /// Sin wave between `low` and `high` with a period of `period_s` and phase offset of `offset_s`
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Sin {
     // User inputs
     period_s: f64,
@@ -17,16 +16,16 @@ pub struct Sin {
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     rad_per_cycle: f64,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     angle_rad: f64,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     scale: f64,
 }
 
@@ -55,7 +54,7 @@ impl Sin {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for Sin {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, ctx: ControllerCtx, _input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/calc/tc_ktype.rs
+++ b/software/deimos/src/calc/tc_ktype.rs
@@ -46,8 +46,7 @@ pub static INTERPOLATOR: Lazy<MulticubicRegular<'static, f64, 2>> = Lazy::new(||
 
 /// Calculate a K-type thermocouple's temperature reading in (K) from voltage,
 /// using the ITS-90 method for cold-junction correction.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct TcKtype {
     // User inputs
     voltage_name: String,
@@ -55,10 +54,10 @@ pub struct TcKtype {
     save_outputs: bool,
 
     // Values provided by calc orchestrator during init
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     input_indices: Vec<usize>,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     output_index: usize,
 }
 
@@ -84,7 +83,7 @@ impl TcKtype {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Calc for TcKtype {
     /// Reset internal state and register calc tape indices
     fn init(&mut self, _: ControllerCtx, input_indices: Vec<usize>, output_range: Range<usize>) {

--- a/software/deimos/src/controller/channel.rs
+++ b/software/deimos/src/controller/channel.rs
@@ -2,8 +2,6 @@
 //! of comms between the controller's appendages
 
 use crossbeam::channel::{Receiver, Sender, bounded};
-
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 /// A basic set of message types that can be passed along a user channel
@@ -22,12 +20,11 @@ pub enum Msg {
 /// endpoints) when deserialized.
 ///
 /// The channel buffers hold a maximum of 10 messages.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Channel {
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     ch0: ChannelInner,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     ch1: ChannelInner,
 }
 
@@ -52,10 +49,9 @@ impl Channel {
 /// Channel endpoint for either a source or sink.
 ///
 /// The channel buffers hold a maximum of 10 messages.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Endpoint {
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     ch: ChannelInner,
 }
 

--- a/software/deimos/src/controller/context.rs
+++ b/software/deimos/src/controller/context.rs
@@ -5,23 +5,14 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use std::{collections::BTreeMap, default::Default};
 
+use super::channel::{Channel, Endpoint};
 use chrono::{DateTime, Utc};
-
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "sideloading")]
 use std::ops::Deref;
-
-#[cfg(feature = "sideloading")]
 use std::sync::{Arc, RwLock};
 
-#[cfg(feature = "sideloading")]
-use super::channel::{Channel, Endpoint};
-
 /// Criteria for exiting the control program
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[non_exhaustive]
 pub enum Termination {
     /// A duration after which the control program should terminate.
@@ -39,8 +30,7 @@ pub enum Termination {
 }
 
 /// Response to losing contact with a peripheral
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[non_exhaustive]
 pub enum LossOfContactPolicy {
     /// Terminate the control program
@@ -56,8 +46,7 @@ pub enum LossOfContactPolicy {
 }
 
 /// Operation context, provided to appendages during init
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[non_exhaustive]
 pub struct ControllerCtx {
     /// A name for this controller op,
@@ -108,14 +97,12 @@ pub struct ControllerCtx {
     /// on its own, the status of these channels should not be used to indicate
     /// when a freerunning thread should terminate, as this will often result in
     /// a resource leak.
-    #[cfg(feature = "sideloading")]
     pub user_channels: Arc<RwLock<BTreeMap<String, Channel>>>,
 }
 
 impl ControllerCtx {
     /// Get a handle to a source endpoint tx/rx pair for the channel,
     /// creating the channel if it does not exist.
-    #[cfg(feature = "sideloading")]
     pub fn source_endpoint(&self, channel_name: &str) -> Endpoint {
         let map = &self.user_channels;
         let inner = map.deref();
@@ -126,7 +113,6 @@ impl ControllerCtx {
 
     /// Get a handle to a sink endpoint tx/rx pair for the channel,
     /// creating the channel if it does not exist.
-    #[cfg(feature = "sideloading")]
     pub fn sink_endpoint(&self, channel_name: &str) -> Endpoint {
         let map = &self.user_channels;
         let inner = map.deref();
@@ -155,7 +141,6 @@ impl Default for ControllerCtx {
             termination_criteria: Vec::new(),
             loss_of_contact_policy: LossOfContactPolicy::Terminate,
             user_ctx: BTreeMap::new(),
-            #[cfg(feature = "sideloading")]
             user_channels: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }

--- a/software/deimos/src/controller/mod.rs
+++ b/software/deimos/src/controller/mod.rs
@@ -1,19 +1,15 @@
 //! Control loop and integration with data pipeline and calc orchestrator
 
-#[cfg(feature = "sideloading")]
 pub mod channel;
-
 pub mod context;
 mod controller_state;
 mod peripheral_state;
 mod timing;
 
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
-
-#[cfg(feature = "ser")]
-use serde::{Deserialize, Serialize};
 
 use flaw::MedianFilter;
 
@@ -34,7 +30,7 @@ use timing::TimingPID;
 /// The controller implements the control loop,
 /// synchronizes sample reporting time between the peripherals,
 /// and dispatches measured data, calculations, and metrics to the data pipeline.
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 pub struct Controller {
     // Input config, which is passed to appendages during their init
     ctx: ControllerCtx,
@@ -327,10 +323,7 @@ impl Controller {
     }
 
     pub fn run(&mut self, plugins: &Option<PluginMap>) -> Result<String, String> {
-        #[cfg(feature = "affinity")]
         let core_ids = core_affinity::get_core_ids().unwrap_or_default();
-
-        #[cfg(feature = "affinity")]
         let mut aux_core_cycle = {
             // Set core affinity, if possible
             // This may not be available on every platform, so it should not break if not available
@@ -414,12 +407,7 @@ impl Controller {
         let mut channel_values = vec![0.0; n_channels];
         for dispatcher in self.dispatchers.iter_mut() {
             dispatcher
-                .init(
-                    &self.ctx,
-                    &channel_names,
-                    #[cfg(feature = "affinity")]
-                    aux_core_cycle.next().unwrap().id,
-                )
+                .init(&self.ctx, &channel_names, aux_core_cycle.next().unwrap().id)
                 .unwrap();
         }
         println!("Dispatching data for {n_channels} channels.");
@@ -819,7 +807,6 @@ mod test {
     /// It is possible to produce a system where a serialized output is not able to be
     /// deserialized without error due to type ambiguity in `dyn Trait` collections,
     /// which is resolved via type tagging here.
-    #[cfg(feature = "ser")]
     #[test]
     fn test_ser_roundtrip() {
         use super::*;

--- a/software/deimos/src/dispatcher/df.rs
+++ b/software/deimos/src/dispatcher/df.rs
@@ -1,31 +1,97 @@
-//! Dataframe dispatcher for in-memory data collection
+//! Dataframe dispatcher for in-memory data collection.
+//! Stores data in a simple library-agnostic in-memory format.
 
-use polars::prelude::*;
-
+use serde::{Deserialize, Serialize};
 use std::{
-    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Arc, RwLock, RwLockWriteGuard},
     time::SystemTime,
 };
-use serde::{Deserialize, Serialize};
 
 use crate::controller::context::ControllerCtx;
 
 use super::{Dispatcher, Overflow, fmt_time, header_columns};
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Row {
+    pub system_time: String,
+    pub timestamp: i64,
+    pub channel_values: Vec<f64>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct SimpleDataFrame {
+    channel_names: Vec<String>,
+    rows: Vec<Row>,
+}
+
+impl SimpleDataFrame {
+    /// Make an empty dataframe that can hold `capacity` rows without reallocating.
+    pub fn new(channel_names: Vec<String>, capacity: usize) -> Self {
+        Self {
+            channel_names,
+            rows: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Push a new row to the end of the list.
+    pub fn push(&mut self, row: Row) {
+        debug_assert!({
+            if self.rows.len() > 0 {
+                row.channel_values.len() == self.rows[0].channel_values.len()
+            } else {
+                true
+            }
+        });
+
+        self.rows.push(row);
+    }
+
+    /// Place a new value at the target index, overwriting existing data.
+    /// If the new index is out of bounds, pushes the new value to the end instead of crashing.
+    pub fn put(&mut self, row: Row, loc: usize) {
+        debug_assert!({
+            if self.rows.len() > 0 {
+                row.channel_values.len() == self.rows[0].channel_values.len()
+            } else {
+                true
+            }
+        });
+
+        if loc >= self.len() {
+            self.push(row);
+        } else {
+            self.rows[loc] = row;
+        }
+    }
+
+    /// The current number of rows stored
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Get column header names including the two time columns
+    pub fn headers(&self) -> Vec<String> {
+        header_columns(&self.channel_names)
+    }
+
+    /// Read-only access to stored row data
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+}
 
 /// Store collected data in in-memory columns, moving columns into
 /// a dataframe behind a shared reference at termination.
 ///
 /// To avoid deadlocks, the dataframe is not updated until after
 /// the run is complete. The dataframe is cleared at the start of each run.
-#[derive(Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct DataFrameDispatcher {
     max_size_megabytes: usize,
     overflow_behavior: Overflow,
-    channel_names: Vec<String>,
     nrows: usize,
     row_index: usize,
-    cols: (Vec<String>, Vec<i64>, Vec<Vec<f64>>),
+    df: Arc<RwLock<SimpleDataFrame>>,
 }
 
 impl DataFrameDispatcher {
@@ -38,10 +104,10 @@ impl DataFrameDispatcher {
     /// data starting with the oldest) or produce an error. Producing a new chunk
     /// is not a valid overflow behavior for this dispatcher.
     pub fn new(
-        df: Arc<RwLock<DataFrame>>,
         max_size_megabytes: usize,
         overflow_behavior: Overflow,
-    ) -> Self {
+        df: Option<Arc<RwLock<SimpleDataFrame>>>,
+    ) -> (Self, Arc<RwLock<SimpleDataFrame>>) {
         // Check if the overflow behavior is valid
         match overflow_behavior {
             Overflow::Wrap => (),
@@ -49,25 +115,26 @@ impl DataFrameDispatcher {
             x => unimplemented!("Overflow behavior {x:?} is not available for DataFrameDispatcher"),
         }
 
-        Self {
-            max_size_megabytes,
-            overflow_behavior,
-            df,
-            ..Default::default()
-        }
+        // Either use an existing dataframe handle, if it is provided,
+        // or create a new empty one.
+        let df = df.unwrap_or_default();
+        let df_handle = df.clone();
+
+        (
+            Self {
+                max_size_megabytes,
+                overflow_behavior,
+                df,
+                ..Default::default()
+            },
+            df_handle,
+        )
     }
 
     /// Get a write handle to the dataframe, if possible
-    fn write(&self) -> Result<RwLockWriteGuard<'_, DataFrame>, String> {
+    fn write(&self) -> Result<RwLockWriteGuard<'_, SimpleDataFrame>, String> {
         self.df
             .try_write()
-            .map_err(|_| "Unable to lock dataframe".to_string())
-    }
-
-    /// Get a read handle to the dataframe, if possible
-    fn read(&self) -> Result<RwLockReadGuard<'_, DataFrame>, String> {
-        self.df
-            .try_read()
             .map_err(|_| "Unable to lock dataframe".to_string())
     }
 }
@@ -80,12 +147,8 @@ impl Dispatcher for DataFrameDispatcher {
         channel_names: &[String],
         _core_assignment: usize,
     ) -> Result<(), String> {
-        // Store channel names for
-        self.channel_names = channel_names.to_vec();
-
-        // Clear dataframe
-        *self.write()? = DataFrame::empty();
-        assert!(self.read()?.is_empty());
+        // Store channel names
+        let channel_names = channel_names.to_vec();
 
         // Reset current row
         self.row_index = 0;
@@ -95,12 +158,8 @@ impl Dispatcher for DataFrameDispatcher {
         let row_size = time_size + (1 + channel_names.len()) * 8;
         self.nrows = (self.max_size_megabytes * 1024 * 1024) / row_size;
 
-        // Set column sizes
-        self.cols = (
-            Vec::with_capacity(self.nrows),
-            Vec::with_capacity(self.nrows),
-            vec![Vec::with_capacity(self.nrows); channel_names.len()],
-        );
+        // Make a fresh dataframe
+        *self.write()? = SimpleDataFrame::new(channel_names, self.nrows);
 
         Ok(())
     }
@@ -113,11 +172,15 @@ impl Dispatcher for DataFrameDispatcher {
     ) -> Result<(), String> {
         // Store data
         let i = self.row_index;
-        put(&mut self.cols.0, fmt_time(time), i);
-        put(&mut self.cols.1, timestamp, i);
-        for j in 0..self.channel_names.len() {
-            put(&mut self.cols.2[j], channel_values[j], i);
-        }
+        let row = Row {
+            system_time: fmt_time(time),
+            timestamp,
+            channel_values,
+        };
+        self.df
+            .write()
+            .map_err(|e| format!("Failed to write dataframe row: {e}"))?
+            .put(row, i);
 
         // Increment
         self.row_index += 1;
@@ -139,20 +202,13 @@ impl Dispatcher for DataFrameDispatcher {
     fn terminate(&mut self) -> Result<(), String> {
         // Clear state, keeping a handle to the same dataframe
         // so that we can run again if needed
-        *self = Self::new(
+        let (dispatcher, _df_handle) = Self::new(
             self.max_size_megabytes,
             self.overflow_behavior,
+            Some(self.df.clone()),
         );
+        (*self) = dispatcher;
 
         Ok(())
-    }
-}
-
-/// Put a value at an index, or, if the index is out of bounds, push the value
-fn put<T>(x: &mut Vec<T>, v: T, i: usize) {
-    if i >= x.len() {
-        x.push(v);
-    } else {
-        x[i] = v;
     }
 }

--- a/software/deimos/src/dispatcher/mod.rs
+++ b/software/deimos/src/dispatcher/mod.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 mod tsdb;
 pub use tsdb::TimescaleDbDispatcher;
-// mod df;
-// pub use df::DataFrameDispatcher;
+mod df;
+pub use df::DataFrameDispatcher;
 
 mod csv;
 pub use csv::CsvDispatcher;

--- a/software/deimos/src/dispatcher/mod.rs
+++ b/software/deimos/src/dispatcher/mod.rs
@@ -1,20 +1,12 @@
 //! Dispatchers send data to an outside consumer, usually a database or display
 
 use chrono::{DateTime, Utc};
-use std::time::SystemTime;
-
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "tsdb")]
+use std::time::SystemTime;
 mod tsdb;
-#[cfg(feature = "tsdb")]
 pub use tsdb::TimescaleDbDispatcher;
-
-#[cfg(feature = "df")]
-mod df;
-#[cfg(feature = "df")]
-pub use df::DataFrameDispatcher;
+// mod df;
+// pub use df::DataFrameDispatcher;
 
 mod csv;
 pub use csv::CsvDispatcher;
@@ -22,8 +14,7 @@ pub use csv::CsvDispatcher;
 use crate::controller::context::ControllerCtx;
 
 /// Choice of behavior when the current file is full
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug)]
 pub enum Overflow {
     /// Wrap back to the beginning of the file and
     /// overwrite, starting with the oldest data
@@ -39,14 +30,14 @@ pub enum Overflow {
 
 /// A data pipeline plugin that receives data from the control loop
 /// one row at a time.
-#[cfg_attr(feature = "ser", typetag::serde(tag = "type"))]
+#[typetag::serde(tag = "type")]
 pub trait Dispatcher: Send + Sync {
     /// Set up the dispatcher at the start of a run
     fn init(
         &mut self,
         ctx: &ControllerCtx,
         channel_names: &[String],
-        #[cfg(feature = "affinity")] core_assignment: usize,
+        core_assignment: usize,
     ) -> Result<(), String>;
 
     /// Ingest a row of data

--- a/software/deimos/src/lib.rs
+++ b/software/deimos/src/lib.rs
@@ -14,8 +14,6 @@ pub use controller::{
 pub use dispatcher::{CsvDispatcher, Dispatcher};
 pub use socket::{Socket, SocketAddr, SocketId, udp::UdpSocket, unix::UnixSocket};
 
-#[cfg(feature = "tsdb")]
 pub use dispatcher::TimescaleDbDispatcher;
 
-#[cfg(feature = "df")]
-pub use dispatcher::DataFrameDispatcher;
+// pub use dispatcher::DataFrameDispatcher;

--- a/software/deimos/src/peripheral/analog_i_rev_2.rs
+++ b/software/deimos/src/peripheral/analog_i_rev_2.rs
@@ -6,17 +6,14 @@ use crate::calc::{Affine, Calc, Constant, InverseAffine, RtdPt100, TcKtype};
 use deimos_shared::states::OperatingMetrics;
 
 use deimos_shared::peripherals::{analog_i_rev_2::*, model_numbers};
-
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AnalogIRev2 {
     pub serial_number: u64,
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Peripheral for AnalogIRev2 {
     fn id(&self) -> PeripheralId {
         PeripheralId {

--- a/software/deimos/src/peripheral/analog_i_rev_3.rs
+++ b/software/deimos/src/peripheral/analog_i_rev_3.rs
@@ -4,16 +4,14 @@ use deimos_shared::OperatingMetrics;
 use deimos_shared::peripherals::{PeripheralId, analog_i_rev_3::*, model_numbers};
 use std::collections::BTreeMap;
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AnalogIRev3 {
     pub serial_number: u64,
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Peripheral for AnalogIRev3 {
     fn id(&self) -> PeripheralId {
         PeripheralId {

--- a/software/deimos/src/peripheral/analog_i_rev_4.rs
+++ b/software/deimos/src/peripheral/analog_i_rev_4.rs
@@ -4,16 +4,14 @@ use deimos_shared::OperatingMetrics;
 use deimos_shared::peripherals::{PeripheralId, analog_i_rev_4::*, model_numbers};
 use std::collections::BTreeMap;
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AnalogIRev4 {
     pub serial_number: u64,
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Peripheral for AnalogIRev4 {
     fn id(&self) -> PeripheralId {
         PeripheralId {

--- a/software/deimos/src/peripheral/mod.rs
+++ b/software/deimos/src/peripheral/mod.rs
@@ -64,7 +64,6 @@ pub static PROTOTYPES: Lazy<BTreeMap<String, Box<dyn Peripheral>>> = Lazy::new(|
 /// Clone isn't inherently object-safe, so to be able to clone dyn trait objects,
 /// we send it for a loop through the serde typetag system, which provides an
 /// automatically-assembled vtable to determine the downcasted type and clone into it.
-#[cfg(feature = "ser")]
 impl Clone for Box<dyn Peripheral> {
     fn clone(&self) -> Box<dyn Peripheral> {
         let new: Box<dyn Peripheral> =
@@ -79,7 +78,7 @@ impl Clone for Box<dyn Peripheral> {
 ///
 /// This is a representation from the perspective of
 /// the application-side controller.
-#[cfg_attr(feature = "ser", typetag::serde(tag = "type"))]
+#[typetag::serde(tag = "type")]
 pub trait Peripheral: Send + Sync + Debug {
     /// Unique device ID combining model number and serial number
     fn id(&self) -> PeripheralId;

--- a/software/deimos/src/socket/mod.rs
+++ b/software/deimos/src/socket/mod.rs
@@ -17,7 +17,7 @@ pub type SocketAddr = (usize, PeripheralId);
 
 /// Packetized socket interface for message-passing
 /// to/from peripherals on different I/O media.
-#[cfg_attr(feature = "ser", typetag::serde(tag = "type"))]
+#[typetag::serde(tag = "type")]
 pub trait Socket: Send + Sync {
     /// Check whether the socket is already open
     fn is_open(&self) -> bool;

--- a/software/deimos/src/socket/udp.rs
+++ b/software/deimos/src/socket/udp.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 use std::time::Instant;
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 use crate::controller::context::ControllerCtx;
@@ -14,18 +13,17 @@ use deimos_shared::peripherals::PeripheralId;
 use deimos_shared::{CONTROLLER_RX_PORT, PERIPHERAL_RX_PORT};
 
 /// Implementation of Socket trait for stdlib UDP socket on IPV4
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct UdpSocket {
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     socket: Option<std::net::UdpSocket>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     rxbuf: Vec<u8>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     addrs: BTreeMap<PeripheralId, std::net::SocketAddr>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     pids: BTreeMap<std::net::SocketAddr, PeripheralId>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     last_received_addr: Option<std::net::SocketAddr>,
 }
 
@@ -41,7 +39,7 @@ impl UdpSocket {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Socket for UdpSocket {
     fn is_open(&self) -> bool {
         self.socket.is_some()

--- a/software/deimos/src/socket/unix.rs
+++ b/software/deimos/src/socket/unix.rs
@@ -7,15 +7,13 @@ use std::os::unix::net; //{SocketAddr, UnixDatagram};
 use std::path::PathBuf;
 use std::time::Instant;
 
-#[cfg(feature = "ser")]
 use serde::{Deserialize, Serialize};
 
 use super::*;
 use deimos_shared::peripherals::PeripheralId;
 
 /// Implementation of Socket trait for stdlib UDP socket on IPV4
-#[cfg_attr(feature = "ser", derive(Serialize, Deserialize))]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct UnixSocket {
     /// The name of the socket will be combined with the op directory
     /// to make a socket address like {op_dir}/sock/{name} .
@@ -27,17 +25,17 @@ pub struct UnixSocket {
     /// the controller in different folder structures.
     name: String,
 
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     socket: Option<net::UnixDatagram>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     rxbuf: Vec<u8>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     addrs: BTreeMap<PeripheralId, PathBuf>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     pids: BTreeMap<PathBuf, PeripheralId>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     last_received_addr: Option<PathBuf>,
-    #[cfg_attr(feature = "ser", serde(skip))]
+    #[serde(skip)]
     ctx: ControllerCtx,
 }
 
@@ -81,7 +79,7 @@ impl UnixSocket {
     }
 }
 
-#[cfg_attr(feature = "ser", typetag::serde)]
+#[typetag::serde]
 impl Socket for UnixSocket {
     fn is_open(&self) -> bool {
         self.socket.is_some()

--- a/software/deimos_gui/Cargo.toml
+++ b/software/deimos_gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deimos_gui"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true
@@ -14,4 +14,4 @@ serde = { version = "^1", features = ["derive", "rc"]}
 serde_json = { version = "^1", features = ["preserve_order"] }
 bimap = { version = "0.6.3", features = ["serde"] }
 
-deimos = { version = "0.9.0", path =  "../deimos",  features = ["all"] }
+deimos = { version = "0.10.0", path =  "../deimos" }


### PR DESCRIPTION
## 2025-06-21 deimos 0.10.0, deimos_gui 0.1.1

### Changed

* Refactor to eliminate all conditional compilation features from control program
  * All features now enabled by default
* Remove polars dep due to excessive build time
* Refactor dataframe dispatcher module to use a lightweight internal dataframe target instead of a polars dataframe
* Update gui dep on control program to not reference features that no longer exist