### PR TITLE
Reduce internal samplerate to 33kHz

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
       uses: obi1kenobi/cargo-semver-checks-action@v2
     - name: Run tests
       run: |
+        cargo build
         cargo test -p deimos
         cargo run --example ipc_plugin
         cargo run --example sideloading

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       uses: obi1kenobi/cargo-semver-checks-action@v2
     - name: Run tests
       run: |
-        cargo test
+        cargo test -p deimos
         cargo run --example ipc_plugin
         cargo run --example sideloading
         cargo build --example multi_daq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-06-25 analog_i_rev4 firmware 0.5.0
+
+### Changed
+
+* Update internal samplerate to 33kHz to restore timing margin that was lost to fractional delay filters
+* Add accumulated sampling time per comm cycle to cycle timing margin metric
+
 ## 2025-06-21 analog_i_rev4 firmware 0.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 2025-06-25 analog_i_rev4 firmware 0.4.0
+## 2025-06-25 analog_i_rev4 firmware 0.4.0, deimos 0.10.1
 
 ### Changed
 
-* Update internal samplerate to 33kHz to restore timing margin that was lost to fractional delay filters
-* Add accumulated sampling time per comm cycle to cycle timing margin metric
+* Firmware
+    * Update internal samplerate to 33kHz to restore timing margin that was lost to fractional delay filters
+    * Add accumulated sampling time per comm cycle to cycle timing margin metric
+* Software
+    * Restore DataFrameDispatcher to top level public API
+    * Remove conditional compilation flags from readme example
 
 ## 2025-06-21 analog_i_rev4 firmware 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2025-06-25 analog_i_rev4 firmware 0.5.0
+## 2025-06-25 analog_i_rev4 firmware 0.4.0
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ opt-level = 3
 codegen-units = 1
 lto = true
 overflow-checks = true
-
-[profile.dev]
-opt-level = 3

--- a/firmware/analog_i_rev4/Cargo.toml
+++ b/firmware/analog_i_rev4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deimos_bare_metal"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,7 +18,7 @@ stm32h7xx-hal = { version = "0.16.0", features=["rt", "revision_v", "stm32h743v"
 #stm32h7xx-hal = { path = "../../../../stm32h7xx-hal", features=["rt", "revision_v", "stm32h743v", "ethernet"] }
 nb = "1.1.0"
 irq = "0.2.3"
-flaw = "0.2.4"
+flaw = "0.2.5"
 atomic_float = "1.1.0"
 array-macro = "2.1.8"
 

--- a/firmware/analog_i_rev4/src/board/mod.rs
+++ b/firmware/analog_i_rev4/src/board/mod.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, AtomicI32};
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32};
 use cortex_m::peripheral::syst::SystClkSource;
 
 use stm32h7xx_hal::{
@@ -37,7 +37,7 @@ use subsystems::pwm::*;
 use subsystems::sampling::*;
 
 /// ADC sample frequency
-pub const ADC_SAMPLE_FREQ_HZ: u32 = 40_000;
+pub const ADC_SAMPLE_FREQ_HZ: u32 = 33_000;
 
 /// ADC voltage reference
 pub const VREF: f32 = 2.5;
@@ -78,6 +78,10 @@ pub static ADC_CUTOFF_RATIO: AtomicF32 = AtomicF32::new(0.1);
 /// Flag for comm loop to indicate to sampling loop
 /// that a new ADC filter cutoff should be incorporated
 pub static NEW_ADC_CUTOFF: AtomicBool = AtomicBool::new(false);
+
+/// Accumulated time spent sampling and filtering since last comm cycle
+pub static ACCUMULATED_SAMPLING_TIME_NS: AtomicU32 = AtomicU32::new(0);
+
 
 #[derive(PartialEq, Eq)]
 pub enum BoardState {

--- a/firmware/analog_i_rev4/src/board/operating.rs
+++ b/firmware/analog_i_rev4/src/board/operating.rs
@@ -171,8 +171,9 @@ impl<'a> Board<'a> {
                 transition_connecting.fetch_or(!ip_address_ok, Ordering::Relaxed);
 
                 // Get overall cycle timing margin and put it in the output
+                let adc_sample_time_ns = ACCUMULATED_SAMPLING_TIME_NS.fetch_and(0, Ordering::Relaxed) as i64;
                 udp_output.metrics.cycle_time_margin_ns =
-                    end_of_cycle - self.board_time(subcycle_res_ns);
+                    end_of_cycle - self.board_time(subcycle_res_ns) - adc_sample_time_ns;
 
                 self.watchdog.feed();
             }

--- a/firmware/analog_i_rev4/src/board/startup.rs
+++ b/firmware/analog_i_rev4/src/board/startup.rs
@@ -11,7 +11,6 @@ use stm32h7xx_hal::{
     gpio::{Output, Pin},
     rcc::rec::AdcClkSel,
     rcc::ResetEnable,
-    stm32::*,
     timer::GetClk,
 };
 

--- a/firmware/analog_i_rev4/src/main.rs
+++ b/firmware/analog_i_rev4/src/main.rs
@@ -8,7 +8,7 @@ extern crate cortex_m;
 extern crate cortex_m_rt as rt;
 
 use rt::{entry, exception};
-use stm32h7xx_hal::{interrupt, pac, prelude::*, stm32, timer::Event};
+use stm32h7xx_hal::{interrupt, pac, stm32, timer::Event};
 
 use core::mem::MaybeUninit;
 use core::panic::PanicInfo;

--- a/software/deimos/Cargo.toml
+++ b/software/deimos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deimos"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["Deimos Controls LLC <support@deimoscontrols.com>"]
 license = "MIT OR Apache-2.0"

--- a/software/deimos/README.md
+++ b/software/deimos/README.md
@@ -108,20 +108,17 @@ let mut controller = Controller::new(ctx);
 // Set up any number of data integrations,
 // all of which will receive the same data at each cycle of the control loop
 //    TSDB-flavored postgres database
-#[cfg(feature="tsdb")]
-{
-    let buffer_window = Duration::from_nanos(1); // Non-buffering mode
-    let retention_time_hours = 1;
-    let timescale_dispatcher: Box<dyn Dispatcher> = Box::new(TimescaleDbDispatcher::new(
-        "<database name>",  // Database name
-        "<database address>", // URL or unix socket interface
-        "<username>",  // Login name; for unix socket, must match OS username
-        "<token env var>",  // Environment variable containing password or token
-        buffer_window,
-        retention_time_hours,
-    ));
-    controller.add_dispatcher(timescale_dispatcher);
-}
+let buffer_window = Duration::from_nanos(1); // Non-buffering mode
+let retention_time_hours = 1;
+let timescale_dispatcher: Box<dyn Dispatcher> = Box::new(TimescaleDbDispatcher::new(
+    "<database name>",  // Database name
+    "<database address>", // URL or unix socket interface
+    "<username>",  // Login name; for unix socket, must match OS username
+    "<token env var>",  // Environment variable containing password or token
+    buffer_window,
+    retention_time_hours,
+));
+controller.add_dispatcher(timescale_dispatcher);
 
 //    A 50MB CSV file that will be wrapped an overwritten when full
 let csv_dispatcher: Box<dyn Dispatcher> =
@@ -150,11 +147,9 @@ controller.set_peripheral_input_source("p2.pwm0_freq", "p1_rtd_5.temperature_K")
 // Serialize and deserialize the controller (for demonstration purposes).
 // All of the configuration up to this point, including any custom peripheral plugins
 // or user-defined calcs, are serialized with the controller and can be written to and read from a json file.
-#[cfg(feature="ser")]
-{
-    let serialized_controller: String = serde_json::to_string_pretty(&controller).unwrap();
-    let _deserialized_controller: Controller = serde_json::from_str(&serialized_controller).unwrap();
-}
+let serialized_controller: String = serde_json::to_string_pretty(&controller).unwrap();
+let _deserialized_controller: Controller = serde_json::from_str(&serialized_controller).unwrap();
+
 
 // Run the control program
 // (skipped here because there are no peripherals

--- a/software/deimos/examples/multi_daq.rs
+++ b/software/deimos/examples/multi_daq.rs
@@ -1,4 +1,4 @@
-//! A 200Hz control program with several DAQ modules connected via UDP and time-synchronized.
+//! A control program with several DAQ modules connected via UDP and time-synchronized.
 //!
 //! Demonstrated here:
 //!   * Setting up a simple control program and connecting to hardware
@@ -37,7 +37,7 @@ fn main() {
     let peripheral_plugins = None;
 
     // Set control rate
-    let rate_hz = 100.0;
+    let rate_hz = 25.0;
     let dt_ns = (1e9_f64 / rate_hz).ceil() as u32;
 
     // Define idle controller
@@ -58,7 +58,7 @@ fn main() {
     controller.add_peripheral("p4", Box::new(AnalogIRev4 { serial_number: 2 }));
     controller.add_peripheral("p5", Box::new(AnalogIRev4 { serial_number: 3 }));
     controller.add_peripheral("p6", Box::new(AnalogIRev4 { serial_number: 4 }));
-    controller.add_peripheral("p7", Box::new(AnalogIRev4 { serial_number: 5 }));
+    // controller.add_peripheral("p7", Box::new(AnalogIRev4 { serial_number: 5 }));
     controller.add_peripheral("p8", Box::new(AnalogIRev4 { serial_number: 6 }));
 
     // Set up database dispatchers

--- a/software/deimos/src/lib.rs
+++ b/software/deimos/src/lib.rs
@@ -14,5 +14,5 @@ pub use controller::{
 pub use dispatcher::{CsvDispatcher, Dispatcher};
 pub use socket::{Socket, SocketAddr, SocketId, udp::UdpSocket, unix::UnixSocket};
 
-pub use dispatcher::TimescaleDbDispatcher;
 pub use dispatcher::DataFrameDispatcher;
+pub use dispatcher::TimescaleDbDispatcher;

--- a/software/deimos/src/lib.rs
+++ b/software/deimos/src/lib.rs
@@ -15,5 +15,4 @@ pub use dispatcher::{CsvDispatcher, Dispatcher};
 pub use socket::{Socket, SocketAddr, SocketId, udp::UdpSocket, unix::UnixSocket};
 
 pub use dispatcher::TimescaleDbDispatcher;
-
-// pub use dispatcher::DataFrameDispatcher;
+pub use dispatcher::DataFrameDispatcher;


### PR DESCRIPTION
## 2025-06-25 analog_i_rev4 firmware 0.4.0, deimos 0.10.1

### Changed

* Firmware
    * Update internal samplerate to 33kHz to restore timing margin that was lost to fractional delay filters
    * Add accumulated sampling time per comm cycle to cycle timing margin metric
* Software
    * Restore DataFrameDispatcher to top level public API
    * Remove conditional compilation flags from readme example