### PR TITLE
Improve python build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,2 @@
-[build]
-rustflags = [
-    "-C", "target-cpu=native",
-]
+[target.'cfg(any(target_arch = "x86_64", target_arch = "x64"))']
+rustflags = ["-C", "target-cpu=x86-64-v3"]

--- a/.github/workflows/notify-website-docs.yml
+++ b/.github/workflows/notify-website-docs.yml
@@ -9,10 +9,11 @@ on:
 
 jobs:
   dispatch:
-    if: ${{ secrets.DEIMOS_WEBSITE_DISPATCH_TOKEN != '' }} && github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch docs build
+        if: ${{ secrets.DEIMOS_WEBSITE_DISPATCH_TOKEN != '' }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/notify-website-docs.yml
+++ b/.github/workflows/notify-website-docs.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch docs build
-        if: ${{ secrets.DEIMOS_WEBSITE_DISPATCH_TOKEN != '' }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -17,9 +17,6 @@ jobs:
 
   linux:
     runs-on: ${{ matrix.platform.runner }}
-    defaults:
-      run:
-        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -55,9 +52,6 @@ jobs:
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
-    defaults:
-      run:
-        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -89,9 +83,6 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
-    defaults:
-      run:
-        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -117,9 +108,6 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
-    defaults:
-      run:
-        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -146,9 +134,6 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./software/deimos
     steps:
       - uses: actions/checkout@v6
       - name: Build sdist
@@ -165,9 +150,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./software/deimos
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [test_python, linux, musllinux, windows, macos, sdist]
     permissions:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -44,7 +44,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --manifest-path software/deimos/Cargo.toml
           # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
@@ -78,7 +78,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --manifest-path software/deimos/Cargo.toml
           # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -107,7 +107,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --manifest-path software/deimos/Cargo.toml
           # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v6
@@ -136,7 +136,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --manifest-path software/deimos/Cargo.toml
           # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v6
@@ -155,7 +155,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
-          args: --out dist
+          args: --out dist --manifest-path software/deimos/Cargo.toml
       - name: Upload sdist
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -22,8 +22,9 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
+          # Removed 32-bit linux due to crashing CI runner
+          # - runner: ubuntu-22.04
+          #   target: x86
           - runner: ubuntu-22.04
             target: aarch64
           - runner: ubuntu-22.04

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -17,6 +17,9 @@ jobs:
 
   linux:
     runs-on: ${{ matrix.platform.runner }}
+    defaults:
+      run:
+        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -52,6 +55,9 @@ jobs:
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
+    defaults:
+      run:
+        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -83,6 +89,9 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
+    defaults:
+      run:
+        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -108,6 +117,9 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
+    defaults:
+      run:
+        working-directory: ./software/deimos
     strategy:
       matrix:
         platform:
@@ -134,6 +146,9 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./software/deimos
     steps:
       - uses: actions/checkout@v6
       - name: Build sdist
@@ -150,6 +165,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./software/deimos
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [test_python, linux, musllinux, windows, macos, sdist]
     permissions:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,6 +2,8 @@ name: test-python
 on:
   pull_request:
     branches: [ "*" ]
+  push:
+    branches: [ "main" ]
   workflow_call:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-01-01 deimos 0.15.0
 
-Broad refactor and many new features to improve usability of software interface.
+Broad refactor and many new features to improve usability of software interface. 
 
 ### Added
 

--- a/software/deimos/Cargo.toml
+++ b/software/deimos/Cargo.toml
@@ -24,7 +24,7 @@ deimos_shared = { path = "../deimos_shared", version = "0.15.0" }
 # Control loop
 chrono = { version = "^0.4.42", features = ["std"], default-features = false }  # timestamp formatting
 core_affinity = "^0.8.3"
-branches = "^0.4.3"
+branches = { version = "^0.4.3", default-features = false }
 
 # Calcs
 flaw = { version = "^0.6.0", default-features = false, features = ["fma"] }

--- a/software/deimos/src/controller/mod.rs
+++ b/software/deimos/src/controller/mod.rs
@@ -16,12 +16,6 @@ use std::time::{Duration, Instant, SystemTime};
 
 use flaw::MedianFilter;
 
-#[cfg(feature = "python")]
-use pyo3::prelude::*;
-
-#[cfg(feature = "python")]
-use crate::python::BackendErr;
-
 use crate::controller::context::LoopMethod;
 use crate::{
     SOCKET_BUFFER_LEN,


### PR DESCRIPTION
* Handle manifest path
* Remove default features on `branches` that use inline-asm that is not available for powerpc python targets
* Remove 32-bit linux target for now due to crashing CI runner