### PR TITLE
Add init-time unit checking across the calc graph

### DIFF
--- a/software/deimos/examples/sideloading.rs
+++ b/software/deimos/examples/sideloading.rs
@@ -107,6 +107,7 @@ impl Calc for Speaker {
         &mut self,
         ctx: ControllerCtx,
         _input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.output_index = output_range.clone().next().unwrap();
@@ -190,6 +191,7 @@ impl Calc for Listener {
         &mut self,
         ctx: ControllerCtx,
         _input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.output_index = output_range.clone().next().unwrap();

--- a/software/deimos/src/calc/affine.rs
+++ b/software/deimos/src/calc/affine.rs
@@ -46,8 +46,14 @@ impl Affine {
     }
 
     /// Attach an output unit label (builder method).
+    ///
+    /// Panics if `unit` is not a recognized UCUM-subset string.
     pub fn with_output_unit(mut self: Box<Self>, unit: impl Into<String>) -> Box<Self> {
-        self.output_unit = Some(unit.into());
+        let unit = unit.into();
+        if let Err(e) = crate::units::parse_unit(&unit) {
+            panic!("Affine::with_output_unit got unparseable unit string {unit:?}: {e}");
+        }
+        self.output_unit = Some(unit);
         self
     }
 }
@@ -77,6 +83,7 @@ impl Calc for Affine {
         &mut self,
         _: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.input_index = input_indices[0];
@@ -118,7 +125,7 @@ impl Calc for Affine {
         Ok(())
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![self.output_unit.clone()]
     }
 

--- a/software/deimos/src/calc/butter.rs
+++ b/software/deimos/src/calc/butter.rs
@@ -76,6 +76,7 @@ impl Calc for Butter2 {
         &mut self,
         ctx: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         assert!(
@@ -142,10 +143,10 @@ impl Calc for Butter2 {
     calc_input_names!(x);
     calc_output_names!(y);
 
-    // FUTURE: passthrough — a filtered voltage is still a voltage. Resolving to the input
-    // channel's unit requires `CalcOrchestrator` to pass channel units into `init`.
-    fn get_output_units(&self) -> Vec<Option<String>> {
-        vec![None]
+    /// A second-order Butterworth low-pass filter does not change the engineering unit of
+    /// its input — a filtered voltage is still a voltage. Adopt the upstream input unit.
+    fn get_output_units(&self, input_units: &[Option<String>]) -> Vec<Option<String>> {
+        vec![input_units.first().cloned().flatten()]
     }
 }
 
@@ -170,7 +171,7 @@ mod tests {
         let mut tape = [0.0f64; 2];
 
         let mut run = || -> Vec<f64> {
-            calc.init(ctx.clone(), vec![0], 1..2).unwrap();
+            calc.init(ctx.clone(), vec![0], vec![None], 1..2).unwrap();
             let mut out = Vec::with_capacity(inputs.len());
             for &x in &inputs {
                 tape[0] = x;

--- a/software/deimos/src/calc/constant.rs
+++ b/software/deimos/src/calc/constant.rs
@@ -35,8 +35,14 @@ impl Constant {
     }
 
     /// Attach an output unit label (builder method).
+    ///
+    /// Panics if `unit` is not a recognized UCUM-subset string.
     pub fn with_output_unit(mut self: Box<Self>, unit: impl Into<String>) -> Box<Self> {
-        self.output_unit = Some(unit.into());
+        let unit = unit.into();
+        if let Err(e) = crate::units::parse_unit(&unit) {
+            panic!("Constant::with_output_unit got unparseable unit string {unit:?}: {e}");
+        }
+        self.output_unit = Some(unit);
         self
     }
 }
@@ -60,6 +66,7 @@ impl Calc for Constant {
         &mut self,
         _: ControllerCtx,
         _: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.output_index = output_range.clone().next().unwrap();
@@ -88,7 +95,7 @@ impl Calc for Constant {
         Err(format!("Unrecognized field {field}"))
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![self.output_unit.clone()]
     }
 

--- a/software/deimos/src/calc/inverse_affine.rs
+++ b/software/deimos/src/calc/inverse_affine.rs
@@ -48,8 +48,14 @@ impl InverseAffine {
     }
 
     /// Attach an output unit label (builder method).
+    ///
+    /// Panics if `unit` is not a recognized UCUM-subset string.
     pub fn with_output_unit(mut self: Box<Self>, unit: impl Into<String>) -> Box<Self> {
-        self.output_unit = Some(unit.into());
+        let unit = unit.into();
+        if let Err(e) = crate::units::parse_unit(&unit) {
+            panic!("InverseAffine::with_output_unit got unparseable unit string {unit:?}: {e}");
+        }
+        self.output_unit = Some(unit);
         self
     }
 }
@@ -79,6 +85,7 @@ impl Calc for InverseAffine {
         &mut self,
         _: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.input_index = input_indices[0];
@@ -120,7 +127,7 @@ impl Calc for InverseAffine {
         Ok(())
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![self.output_unit.clone()]
     }
 

--- a/software/deimos/src/calc/mod.rs
+++ b/software/deimos/src/calc/mod.rs
@@ -68,11 +68,18 @@ impl Clone for Box<dyn Calc> {
 /// at each timestep, and may have some persistent internal state.
 #[typetag::serde(tag = "type")]
 pub trait Calc: Send + Sync + Debug {
-    /// Reset internal state and register calc tape indices
+    /// Reset internal state and register calc tape indices.
+    ///
+    /// `input_units` is parallel to `input_indices` (same length, same order as
+    /// `get_input_names`) and carries the upstream-declared engineering unit for each
+    /// input — `None` if the upstream declares none. No built-in calc reads `input_units`
+    /// in `init` today; passthrough-inheritance calcs (`Butter2`, `Pid`) consult it in
+    /// `get_output_units` instead.
     fn init(
         &mut self,
         ctx: ControllerCtx,
         input_indices: Vec<usize>,
+        input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String>;
 
@@ -117,11 +124,30 @@ pub trait Calc: Send + Sync + Debug {
     /// Must return a `Vec` whose length equals `get_output_names().len()`.
     /// `None` indicates the unit is unknown or not applicable for that output.
     ///
+    /// `input_units` carries the upstream-declared unit for each of this calc's inputs in
+    /// the same order as `get_input_names`. Most calcs ignore it and return their static
+    /// declaration. Passthrough-inheritance calcs (`Butter2`, `Pid`) read it: their declared
+    /// output unit is the unit of their (single) input channel.
+    ///
     /// The default implementation returns `vec![None; N]` where `N` is the number of outputs,
     /// which is correct for calcs that do not transform engineering units (pass-through or
     /// untyped outputs). Override when the calc declares concrete output units.
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![None; self.get_output_names().len()]
+    }
+
+    /// List of optional expected input units, parallel to `get_input_names`.
+    /// Must return a `Vec` whose length equals `get_input_names().len()`.
+    ///
+    /// `None` for an entry means "this calc declares no expectation; accept any input unit
+    /// (including `None`)." `Some(unit)` means the orchestrator will fail controller init if
+    /// the upstream channel's declared unit does not match.
+    ///
+    /// The default implementation returns `vec![None; N]` so unit-agnostic calcs (and
+    /// third-party plugins that do not override) compile and pass the orchestrator's
+    /// pass-1 check.
+    fn get_input_units(&self) -> Vec<Option<String>> {
+        vec![None; self.get_input_names().len()]
     }
 
     /// Get the type name, which is guaranteed to be unique among implementations of the trait
@@ -206,8 +232,12 @@ mod tests {
     use super::*;
 
     fn assert_units_len_matches_names_len(calc: &dyn Calc) {
+        // Stub `input_units` slice — equality-only calcs ignore the arg, and passthrough calcs
+        // (`Butter2`, `Pid`) treat a `None` input as a `None` output, both of which preserve
+        // the length-equality invariant the test asserts.
+        let input_units: Vec<Option<String>> = vec![None; calc.get_input_names().len()];
         assert_eq!(
-            calc.get_output_units().len(),
+            calc.get_output_units(&input_units).len(),
             calc.get_output_names().len(),
             "get_output_units().len() != get_output_names().len() for {}",
             calc.kind()
@@ -262,6 +292,52 @@ mod tests {
             false,
         );
         assert_units_len_matches_names_len(&*calc);
+    }
+
+    #[test]
+    fn butter2_inherits_input_unit() {
+        let calc = Butter2::new("x".to_owned(), 10.0, false);
+
+        // Upstream declares a unit -> Butter2 adopts it.
+        assert_eq!(
+            calc.get_output_units(&[Some("K".to_owned())]),
+            vec![Some("K".to_owned())],
+            "Butter2 must passthrough the input unit when one is declared"
+        );
+
+        // Upstream declares no unit -> Butter2 stays None.
+        assert_eq!(
+            calc.get_output_units(&[None]),
+            vec![None],
+            "Butter2 must remain None when the input declares no unit"
+        );
+    }
+
+    #[test]
+    fn pid_inherits_input_unit() {
+        let calc = Pid::new(
+            "measurement".to_owned(),
+            "setpoint".to_owned(),
+            1.0,
+            0.0,
+            0.0,
+            100.0,
+            false,
+        );
+
+        // `measurement` is the index-0 input by `calc_input_names!(measurement, setpoint)`,
+        // so a Some at index 0 must propagate to the output.
+        assert_eq!(
+            calc.get_output_units(&[Some("K".to_owned()), None]),
+            vec![Some("K".to_owned())],
+            "Pid must passthrough the measurement input's unit"
+        );
+
+        assert_eq!(
+            calc.get_output_units(&[None, None]),
+            vec![None],
+            "Pid must remain None when the measurement input declares no unit"
+        );
     }
 
     #[test]

--- a/software/deimos/src/calc/orchestrator.rs
+++ b/software/deimos/src/calc/orchestrator.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 use serde::{Deserialize, Serialize};
 
 use crate::ControllerCtx;
+use crate::units;
 use crate::{calc::*, peripheral::Peripheral};
 use deimos_shared::states::OperatingMetrics;
 
@@ -17,6 +18,18 @@ struct CalcOrchestratorState {
     /// Values of every input and output field for calcs and peripherals.
     /// Notably does not include peripheral metrics.
     calc_tape: Vec<f64>,
+
+    /// Declared engineering unit per calc-tape index, parallel to `calc_tape`.
+    /// Peripheral input/output entries are `None` (peripherals don't declare
+    /// per-channel units in this scope). Calc-output entries are filled in
+    /// during pass 1 of `init` from each calc's `get_output_units(input_units)`.
+    ///
+    /// Metric channels (per-peripheral and controller-side) are NOT on the
+    /// calc tape and do not appear here. Their declared units come from
+    /// `Peripheral::metric_units` and `ControllerOperatingMetrics::units_to_write`,
+    /// and reach `ControllerCtx::channel_units` via
+    /// `ControllerState::get_units_to_write`.
+    tape_units: Vec<Option<String>>,
 
     /// Calc names in the order that they are evaluated at each cycle
     eval_order: Vec<CalcName>,
@@ -239,23 +252,15 @@ impl CalcOrchestrator {
 
     /// Get units of fields marked to dispatch, in the same order as `get_dispatch_names`.
     ///
-    /// Returns `None` for peripheral inputs and outputs (which carry no declared unit) and for
-    /// calc outputs whose calc does not override `get_output_units`.
+    /// Reads from the per-tape-index unit slice that pass 1 of `init` resolved.
+    /// Returns `None` for peripheral inputs and outputs (which carry no declared
+    /// unit on the calc tape) and for calc outputs whose calc returned `None`
+    /// from `get_output_units`.
     pub fn get_dispatch_units(&self) -> Vec<Option<String>> {
         self.state
-            .dispatch_names
+            .dispatch_indices
             .iter()
-            .map(|field_name| {
-                // Field names are "node_name.output_name". Split on the first `.`.
-                let (node_name, output_name) = match field_name.split_once('.') {
-                    Some(parts) => parts,
-                    None => return None,
-                };
-                let calc = self.calcs.get(node_name)?;
-                let output_names = calc.get_output_names();
-                let output_index = output_names.iter().position(|n| n == output_name)?;
-                calc.get_output_units().get(output_index)?.clone()
-            })
+            .map(|&i| self.state.tape_units.get(i).cloned().flatten())
             .collect()
     }
 
@@ -693,23 +698,49 @@ impl CalcOrchestrator {
                 dispatch_indices.push(i);
             }
         }
-        //    Calcs, in eval order
+        //    Calcs, in eval order — two passes:
+        //      Pass 1 walks calcs in dependency order to (a) assemble each
+        //      calc's input/output tape ranges, (b) compute its declared
+        //      output units via `get_output_units(input_units)` so passthrough
+        //      calcs (`Butter2`, `Pid`) inherit upstream units, and
+        //      (c) validate the calc's `get_input_units` against the
+        //      so-far-resolved upstream units. The first mismatch fails init
+        //      before any calc-side `init` runs.
+        //
+        //      Pass 2 walks the same `eval_order` and invokes each calc's
+        //      `init` with the assembled `input_units` slice.
+        //
+        // Per-calc binding info captured in pass 1, replayed in pass 2 to
+        // avoid recomputing input_indices / output_range.
+        struct CalcBinding {
+            calc_name: CalcName,
+            input_indices: Vec<usize>,
+            input_units: Vec<Option<String>>,
+            output_range: Range<usize>,
+        }
+        let mut bindings: Vec<CalcBinding> = Vec::with_capacity(eval_order.len());
+
+        // Tape unit slice, parallel to `fields_order`. Peripheral input/output
+        // entries are `None` (no per-channel declared unit at this layer);
+        // calc-output entries get filled in below from `get_output_units`.
+        let mut tape_units: Vec<Option<String>> = vec![None; fields_order.len()];
+
+        // Pass 1: resolve unit topology + bind tape indices.
         for calc_name in &eval_order {
-            // Unpack
             let calc = self
                 .calcs
-                .get_mut(calc_name)
+                .get(calc_name)
                 .ok_or_else(|| format!("Calc `{calc_name}` missing from registry"))?;
             let input_map = calc.get_input_map();
             let save_outputs = calc.get_save_outputs();
-            let input_names = &calc.get_input_names();
-            let output_names = &calc.get_output_names();
+            let input_names = calc.get_input_names();
+            let output_names = calc.get_output_names();
             let n_outputs = output_names.len();
 
-            // Find input indices from the part of the map that has
-            // been built so far
-            let mut input_indices = Vec::new();
-            for input_name in input_names {
+            // Resolve input tape indices from the field map built so far.
+            let mut input_indices = Vec::with_capacity(input_names.len());
+            let mut input_source_fields: Vec<FieldName> = Vec::with_capacity(input_names.len());
+            for input_name in &input_names {
                 let src_field = input_map.get(input_name).ok_or_else(|| {
                     format!("Calc `{calc_name}` missing mapping for input `{input_name}`")
                 })?;
@@ -717,28 +748,121 @@ impl CalcOrchestrator {
                     format!("Did not find field index for `{src_field}` while initializing `{calc_name}`")
                 })?;
                 input_indices.push(src_index);
+                input_source_fields.push(src_field.clone());
             }
 
-            // Set output range
+            // Look up each input's upstream-declared unit from the running
+            // tape-unit slice.
+            let input_units: Vec<Option<String>> = input_indices
+                .iter()
+                .map(|&idx| tape_units[idx].clone())
+                .collect();
+
+            // Validate this calc's declared input expectations against the
+            // upstream-declared units. First mismatch returns `Err` — no
+            // pass-2 calc-side `init` runs.
+            let declared_input_units = calc.get_input_units();
+            if declared_input_units.len() != input_names.len() {
+                return Err(format!(
+                    "Calc `{calc_name}`: get_input_units().len() = {} \
+                     != get_input_names().len() = {}",
+                    declared_input_units.len(),
+                    input_names.len(),
+                ));
+            }
+            for (i, declared) in declared_input_units.iter().enumerate() {
+                let upstream = &input_units[i];
+                let (Some(declared_unit), Some(upstream_unit)) = (declared, upstream) else {
+                    // A `None` on either side carries no unit to compare, so it passes.
+                    continue;
+                };
+                let dest_kind = calc.kind();
+                let dest_field = &input_names[i];
+                let source_name = &input_source_fields[i];
+                match units::units_equal(declared_unit, upstream_unit) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(units::unit_mismatch_message(
+                            &dest_kind,
+                            dest_field,
+                            source_name,
+                            Some(declared_unit),
+                            Some(upstream_unit),
+                        ));
+                    }
+                    Err(parse_err) => {
+                        // One side didn't parse. Treat as a mismatch with the
+                        // verbatim string echoed (the parse error already
+                        // contains the bad input): an unparseable unit is a
+                        // mismatch.
+                        return Err(format!(
+                            "{} (parse error: {parse_err})",
+                            units::unit_mismatch_message(
+                                &dest_kind,
+                                dest_field,
+                                source_name,
+                                Some(declared_unit),
+                                Some(upstream_unit),
+                            )
+                        ));
+                    }
+                }
+            }
+
+            // Compute this calc's declared output units now that we have the
+            // upstream `input_units` to pass through (Butter2/Pid use this).
+            let declared_output_units = calc.get_output_units(&input_units);
+            if declared_output_units.len() != n_outputs {
+                return Err(format!(
+                    "Calc `{calc_name}`: get_output_units().len() = {} \
+                     != get_output_names().len() = {}",
+                    declared_output_units.len(),
+                    n_outputs,
+                ));
+            }
+
+            // Lay out the calc's outputs on the tape, mark for dispatch, and
+            // record the unit slice in parallel.
             let start = fields_order.len();
             let end = start + n_outputs;
             let output_range = start..end;
-
-            // Set output order
-            for (i, output_name) in (start..).zip(output_names.iter()) {
+            for (offset, output_name) in output_names.iter().enumerate() {
+                let i = start + offset;
                 let output_field = format!("{calc_name}.{output_name}");
                 fields_order.push(output_field.clone());
                 field_index_map.insert(output_field.clone(), i);
+                tape_units.push(declared_output_units[offset].clone());
 
-                // Mark fields for dispatch
                 if save_outputs {
                     dispatch_names.push(output_field.clone());
                     dispatch_indices.push(i);
                 }
             }
+            debug_assert_eq!(tape_units.len(), end);
 
-            // Initialize this calc
-            calc.init(ctx.clone(), input_indices, output_range)?;
+            bindings.push(CalcBinding {
+                calc_name: calc_name.clone(),
+                input_indices,
+                input_units,
+                output_range,
+            });
+        }
+
+        // Pass 2: bind tape indices on the calc and run its `init`. All
+        // unit checks have already passed; nothing here can return a unit
+        // mismatch.
+        for binding in bindings {
+            let CalcBinding {
+                calc_name,
+                input_indices,
+                input_units,
+                output_range,
+            } = binding;
+            let calc = self
+                .calcs
+                .get_mut(&calc_name)
+                .ok_or_else(|| format!("Calc `{calc_name}` missing from registry"))?;
+            calc.init(ctx.clone(), input_indices, input_units, output_range)?;
         }
 
         // Find the indices of fields that will be given to the peripherals
@@ -769,10 +893,12 @@ impl CalcOrchestrator {
 
         // Initialize the calc tape
         let calc_tape: Vec<f64> = vec![0.0_f64; fields_order.len()];
+        debug_assert_eq!(tape_units.len(), calc_tape.len());
 
         // Take new internal state
         self.state = CalcOrchestratorState {
             calc_tape,
+            tape_units,
             eval_order,
             dispatch_names,
             dispatch_indices,
@@ -825,5 +951,398 @@ mod tests {
         assert!(dot.contains("\"periph::p::out\":out_0 -> \"calc::c0\":in_0;"));
         assert!(dot.contains("\"calc::c0\":out_0 -> \"calc::c1\":in_0;"));
         assert!(dot.contains("\"calc::c1\":out_0 -> \"periph::p::in\":in_0;"));
+    }
+
+    /// Test-only calc fixture that declares fixed input/output unit
+    /// expectations. Used to exercise the orchestrator's pass-1 unit check
+    /// without depending on `RtdPt100`/`Affine` or other concrete calcs.
+    ///
+    /// `output_for_input` defaults to `vec![None]`; tests can override it
+    /// with a fixed `Some(unit)` to drive a downstream mismatch.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct UnitFixture {
+        input_field: String,
+        declared_input: Option<String>,
+        declared_output: Option<String>,
+    }
+
+    #[typetag::serde]
+    impl Calc for UnitFixture {
+        fn init(
+            &mut self,
+            _: ControllerCtx,
+            _input_indices: Vec<usize>,
+            _input_units: Vec<Option<String>>,
+            _output_range: Range<usize>,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn terminate(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+        fn eval(&mut self, _tape: &mut [f64]) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_input_map(&self) -> BTreeMap<CalcInputName, FieldName> {
+            let mut m = BTreeMap::new();
+            m.insert("x".to_owned(), self.input_field.clone());
+            m
+        }
+        fn update_input_map(&mut self, field: &str, source: &str) -> Result<(), String> {
+            if field == "x" {
+                self.input_field = source.to_owned();
+                Ok(())
+            } else {
+                Err(format!("Unrecognized field {field}"))
+            }
+        }
+        fn get_save_outputs(&self) -> bool {
+            true
+        }
+        fn set_save_outputs(&mut self, _v: bool) {}
+        fn get_config(&self) -> BTreeMap<String, f64> {
+            BTreeMap::new()
+        }
+        fn set_config(&mut self, _: &BTreeMap<String, f64>) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_input_names(&self) -> Vec<CalcInputName> {
+            vec!["x".to_owned()]
+        }
+        fn get_output_names(&self) -> Vec<CalcOutputName> {
+            vec!["y".to_owned()]
+        }
+        fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
+            vec![self.declared_output.clone()]
+        }
+        fn get_input_units(&self) -> Vec<Option<String>> {
+            vec![self.declared_input.clone()]
+        }
+    }
+
+    /// Build an orchestrator wiring `source -> sink` where both are
+    /// `UnitFixture` calcs. `source` declares only an output unit and reads
+    /// from a peripheral channel that itself carries no declared unit.
+    fn two_calc_orchestrator(
+        peripheral_field: &str,
+        source_output: Option<&str>,
+        sink_input: Option<&str>,
+    ) -> CalcOrchestrator {
+        let mut o = CalcOrchestrator::default();
+        o.add_calc(
+            "src",
+            Box::new(UnitFixture {
+                input_field: peripheral_field.to_owned(),
+                declared_input: None,
+                declared_output: source_output.map(|s| s.to_owned()),
+            }),
+        );
+        o.add_calc(
+            "sink",
+            Box::new(UnitFixture {
+                input_field: "src.y".to_owned(),
+                declared_input: sink_input.map(|s| s.to_owned()),
+                declared_output: None,
+            }),
+        );
+        o
+    }
+
+    #[test]
+    fn k_to_celsius_wire_fails_init_with_affine_hint() {
+        // Source declares K, sink declares °C — same dimension, different
+        // scale. Pass 1 must fail init with a message that names both unit
+        // strings AND includes the copy-pasteable Affine hint.
+        let mut orch = two_calc_orchestrator("p.ain0", Some("K"), Some("°C"));
+        let peripherals: BTreeMap<String, Box<dyn Peripheral>> = BTreeMap::from([(
+            "p".to_owned(),
+            Box::new(AnalogIRev3 { serial_number: 1 }) as _,
+        )]);
+        let err = orch
+            .init(ControllerCtx::default(), &peripherals)
+            .unwrap_err();
+        assert!(err.contains("K"), "missing K in error: {err}");
+        assert!(err.contains("°C"), "missing °C in error: {err}");
+        assert!(err.contains("offset=-273.15"), "missing affine hint: {err}");
+    }
+
+    #[test]
+    fn mismatch_error_includes_all_required_fields() {
+        // Pa upstream → K downstream — different dimensions. The error must
+        // include: dest calc kind, dest input field, source name, both unit
+        // strings, and a dimensional reason.
+        let mut orch = two_calc_orchestrator("p.ain0", Some("Pa"), Some("K"));
+        let peripherals: BTreeMap<String, Box<dyn Peripheral>> = BTreeMap::from([(
+            "p".to_owned(),
+            Box::new(AnalogIRev3 { serial_number: 1 }) as _,
+        )]);
+        let err = orch
+            .init(ControllerCtx::default(), &peripherals)
+            .unwrap_err();
+        assert!(err.contains("UnitFixture"), "missing dest calc kind: {err}");
+        assert!(err.contains("`x`"), "missing dest input field: {err}");
+        assert!(err.contains("src.y"), "missing source name: {err}");
+        assert!(err.contains("K"), "missing dest unit: {err}");
+        assert!(err.contains("Pa"), "missing source unit: {err}");
+        // Dimensional reason — the `describe()` method renders dim names.
+        assert!(
+            err.contains("dimensions") || err.contains("temperature"),
+            "missing dimensional reason: {err}"
+        );
+    }
+
+    #[test]
+    fn matching_units_pass_init() {
+        // Sanity check: source K, sink K must succeed.
+        let mut orch = two_calc_orchestrator("p.ain0", Some("K"), Some("K"));
+        let peripherals: BTreeMap<String, Box<dyn Peripheral>> = BTreeMap::from([(
+            "p".to_owned(),
+            Box::new(AnalogIRev3 { serial_number: 1 }) as _,
+        )]);
+        orch.init(ControllerCtx::default(), &peripherals).unwrap();
+        // Confirm `get_dispatch_units` reflects the resolved per-tape unit.
+        let names = orch.get_dispatch_names();
+        let units = orch.get_dispatch_units();
+        assert_eq!(names.len(), units.len());
+        let src_idx = names.iter().position(|n| n == "src.y").unwrap();
+        assert_eq!(units[src_idx], Some("K".to_owned()));
+    }
+
+    #[test]
+    fn none_on_either_side_does_not_fail_init() {
+        // Source declares nothing, sink declares K — no mismatch (sink has
+        // no upstream unit to compare against; the `None` upstream passes).
+        let mut orch = two_calc_orchestrator("p.ain0", None, Some("K"));
+        let peripherals: BTreeMap<String, Box<dyn Peripheral>> = BTreeMap::from([(
+            "p".to_owned(),
+            Box::new(AnalogIRev3 { serial_number: 1 }) as _,
+        )]);
+        orch.init(ControllerCtx::default(), &peripherals).unwrap();
+    }
+
+    // End-to-end tests exercise the full `CalcOrchestrator::init` pipeline
+    // using production calcs (`RtdPt100`, `Butter2`) wired into test-only
+    // sinks that declare specific input units. Together with the unit-level
+    // tests above they cover the seam between the orchestrator's pass-1 unit
+    // topology and pass-2 calc-side init.
+
+    use crate::calc::{Butter2, RtdPt100};
+
+    /// Build a peripheral map with a single `AnalogIRev3` named `p`.
+    /// `RtdPt100` reads `p.ain<i>` as a resistance signal in these tests; we
+    /// don't run the controller, only init, so no driver is needed.
+    fn analog_peripheral_map() -> BTreeMap<String, Box<dyn Peripheral>> {
+        BTreeMap::from([(
+            "p".to_owned(),
+            Box::new(AnalogIRev3 { serial_number: 1 }) as _,
+        )])
+    }
+
+    #[test]
+    fn e2e_rtd_to_affine_pa_fails_init() {
+        // `RtdPt100` produces K. The downstream sink declares input unit
+        // `Pa`. Pass 1 must catch the dimensional mismatch and fail init
+        // with a message that names the upstream unit `K`, the downstream
+        // unit `Pa`, the destination calc kind, and a dimensional reason.
+        //
+        // We use `UnitFixture` as the test sink rather than the real `Affine`
+        // because `Affine` does not declare an input unit — its
+        // `get_input_units` returns the trait default (all-`None`). Keeping
+        // the test self-contained avoids growing `Affine`'s public surface
+        // just for the test.
+        let mut orch = CalcOrchestrator::default();
+        orch.add_calc("rtd", RtdPt100::new("p.ain0".to_owned(), true));
+        orch.add_calc(
+            "sink",
+            Box::new(UnitFixture {
+                input_field: "rtd.temperature_K".to_owned(),
+                declared_input: Some("Pa".to_owned()),
+                declared_output: None,
+            }),
+        );
+
+        let peripherals = analog_peripheral_map();
+        let err = orch
+            .init(ControllerCtx::default(), &peripherals)
+            .unwrap_err();
+
+        // Required fields in the mismatch error:
+        assert!(err.contains("K"), "missing source unit K: {err}");
+        assert!(err.contains("Pa"), "missing dest unit Pa: {err}");
+        assert!(err.contains("UnitFixture"), "missing dest calc kind: {err}");
+        assert!(
+            err.contains("rtd.temperature_K"),
+            "missing source name: {err}"
+        );
+        assert!(
+            err.contains("different dimensions")
+                || (err.contains("temperature") && err.contains("pressure")),
+            "missing dimensional reason: {err}"
+        );
+    }
+
+    #[test]
+    fn e2e_butter2_passes_unit_through_to_dispatch() {
+        // `RtdPt100`(K) -> `Butter2` -> sink(declared input K). Pass 1 must
+        // resolve `Butter2`'s output unit to `K` (passthrough inheritance
+        // from its input), the sink's K declaration must accept the K
+        // upstream, and `get_dispatch_units` must report `K` for the
+        // `Butter2` output. This is the regression test that catches a
+        // refactor that breaks Butter2's passthrough survival end-to-end.
+        let mut orch = CalcOrchestrator::default();
+        orch.add_calc("rtd", RtdPt100::new("p.ain0".to_owned(), true));
+        orch.add_calc(
+            "filt",
+            // `cutoff_hz=5.0` is a placeholder; we don't run `eval`, only
+            // `init`. The orchestrator only calls `get_output_units` and
+            // `init` on Butter2 here.
+            Butter2::new("rtd.temperature_K".to_owned(), 5.0, true),
+        );
+        orch.add_calc(
+            "sink",
+            Box::new(UnitFixture {
+                input_field: "filt.y".to_owned(),
+                declared_input: Some("K".to_owned()),
+                declared_output: None,
+            }),
+        );
+
+        let peripherals = analog_peripheral_map();
+        // Butter2::init asserts dt_ns > 0, so use a realistic ctx.
+        let ctx = ControllerCtx {
+            dt_ns: 50_000_000, // 20 Hz
+            ..Default::default()
+        };
+        orch.init(ctx, &peripherals).unwrap();
+
+        let names = orch.get_dispatch_names();
+        let units = orch.get_dispatch_units();
+        assert_eq!(names.len(), units.len(), "names/units length mismatch");
+
+        // The Butter2 output `filt.y` must carry the upstream's K through
+        // to the dispatcher's view of declared units.
+        let filt_idx = names
+            .iter()
+            .position(|n| n == "filt.y")
+            .expect("filt.y missing from dispatch names");
+        assert_eq!(
+            units[filt_idx],
+            Some("K".to_owned()),
+            "Butter2 output unit must be K (passthrough from RtdPt100)"
+        );
+
+        // Sanity: the upstream RtdPt100 output is also K.
+        let rtd_idx = names
+            .iter()
+            .position(|n| n == "rtd.temperature_K")
+            .expect("rtd.temperature_K missing from dispatch names");
+        assert_eq!(units[rtd_idx], Some("K".to_owned()));
+    }
+
+    /// One-input fixture whose `get_input_units` returns a length that does
+    /// not match `get_input_names`, used to exercise the orchestrator's
+    /// length-equality guard at pass 1.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct WrongInputUnitsLen {
+        input_field: String,
+    }
+
+    #[typetag::serde]
+    impl Calc for WrongInputUnitsLen {
+        fn init(
+            &mut self,
+            _: ControllerCtx,
+            _: Vec<usize>,
+            _: Vec<Option<String>>,
+            _: Range<usize>,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn terminate(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+        fn eval(&mut self, _tape: &mut [f64]) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_input_map(&self) -> BTreeMap<CalcInputName, FieldName> {
+            let mut m = BTreeMap::new();
+            m.insert("x".to_owned(), self.input_field.clone());
+            m
+        }
+        fn update_input_map(&mut self, _: &str, _: &str) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_save_outputs(&self) -> bool {
+            false
+        }
+        fn set_save_outputs(&mut self, _v: bool) {}
+        fn get_config(&self) -> BTreeMap<String, f64> {
+            BTreeMap::new()
+        }
+        fn set_config(&mut self, _: &BTreeMap<String, f64>) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_input_names(&self) -> Vec<CalcInputName> {
+            vec!["x".to_owned()]
+        }
+        fn get_output_names(&self) -> Vec<CalcOutputName> {
+            vec!["y".to_owned()]
+        }
+        fn get_input_units(&self) -> Vec<Option<String>> {
+            // Intentionally length-2 against a length-1 input list.
+            vec![None, None]
+        }
+    }
+
+    #[test]
+    fn input_units_len_mismatch_fails_init() {
+        let mut orch = CalcOrchestrator::default();
+        orch.add_calc("rtd", RtdPt100::new("p.ain0".to_owned(), true));
+        orch.add_calc(
+            "buggy",
+            Box::new(WrongInputUnitsLen {
+                input_field: "rtd.temperature_K".to_owned(),
+            }),
+        );
+
+        let peripherals = analog_peripheral_map();
+        let err = orch
+            .init(ControllerCtx::default(), &peripherals)
+            .unwrap_err();
+        assert!(
+            err.contains("get_input_units().len()"),
+            "length-mismatch error must name the offending accessor: {err}"
+        );
+        assert!(
+            err.contains("buggy"),
+            "length-mismatch error must name the calc: {err}"
+        );
+    }
+
+    #[test]
+    fn e2e_unparseable_dest_unit_fails_init() {
+        // An unparseable declared-input unit on the downstream calc must
+        // still fail init (not silently pass): an unparseable string at any
+        // boundary that performs a check is treated as a mismatch, and the
+        // offending string appears verbatim in the error.
+        let mut orch = CalcOrchestrator::default();
+        orch.add_calc("rtd", RtdPt100::new("p.ain0".to_owned(), true));
+        orch.add_calc(
+            "sink",
+            Box::new(UnitFixture {
+                input_field: "rtd.temperature_K".to_owned(),
+                declared_input: Some("furlongs".to_owned()),
+                declared_output: None,
+            }),
+        );
+
+        let peripherals = analog_peripheral_map();
+        let err = orch
+            .init(ControllerCtx::default(), &peripherals)
+            .unwrap_err();
+        assert!(
+            err.contains("furlongs"),
+            "unparseable unit string must appear verbatim: {err}"
+        );
     }
 }

--- a/software/deimos/src/calc/pid.rs
+++ b/software/deimos/src/calc/pid.rs
@@ -103,6 +103,7 @@ impl Calc for Pid {
         &mut self,
         ctx: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         assert!(
@@ -169,9 +170,10 @@ impl Calc for Pid {
     calc_input_names!(measurement, setpoint);
     calc_output_names!(y);
 
-    // FUTURE: PID output usually inherits the measurement's unit. Resolving it requires
-    // `CalcOrchestrator` to pass channel units into `init`.
-    fn get_output_units(&self) -> Vec<Option<String>> {
-        vec![None]
+    /// A PID controller's output carries the unit of its error signal, which is the unit of
+    /// the `measurement` input (index 0 by convention from
+    /// `calc_input_names!(measurement, setpoint)`). Adopt the measurement input's unit.
+    fn get_output_units(&self, input_units: &[Option<String>]) -> Vec<Option<String>> {
+        vec![input_units.first().cloned().flatten()]
     }
 }

--- a/software/deimos/src/calc/polynomial.rs
+++ b/software/deimos/src/calc/polynomial.rs
@@ -52,8 +52,14 @@ impl Polynomial {
     }
 
     /// Attach an output unit label (builder method).
+    ///
+    /// Panics if `unit` is not a recognized UCUM-subset string.
     pub fn with_output_unit(mut self: Box<Self>, unit: impl Into<String>) -> Box<Self> {
-        self.output_unit = Some(unit.into());
+        let unit = unit.into();
+        if let Err(e) = crate::units::parse_unit(&unit) {
+            panic!("Polynomial::with_output_unit got unparseable unit string {unit:?}: {e}");
+        }
+        self.output_unit = Some(unit);
         self
     }
 
@@ -99,6 +105,7 @@ impl Calc for Polynomial {
         &mut self,
         _: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         if self.coefficients.is_empty() {
@@ -143,7 +150,7 @@ impl Calc for Polynomial {
         }
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![self.output_unit.clone()]
     }
 

--- a/software/deimos/src/calc/rtd_pt100.rs
+++ b/software/deimos/src/calc/rtd_pt100.rs
@@ -80,6 +80,7 @@ impl Calc for RtdPt100 {
         &mut self,
         _: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.input_index = input_indices[0];
@@ -127,7 +128,7 @@ impl Calc for RtdPt100 {
         Ok(())
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![Some("K".to_owned())]
     }
 

--- a/software/deimos/src/calc/sequence_machine/mod.rs
+++ b/software/deimos/src/calc/sequence_machine/mod.rs
@@ -547,6 +547,7 @@ impl Calc for SequenceMachine {
         &mut self,
         ctx: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         // Reload from folder, if linked
@@ -659,7 +660,7 @@ impl Calc for SequenceMachine {
     }
 
     /// `sequence_time_s` is in seconds; user-defined data channels have no declared unit.
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         let n_data = self.entry_sequence().data.len();
         let mut units = vec![Some("s".to_owned())];
         units.extend(std::iter::repeat_n(None, n_data));

--- a/software/deimos/src/calc/sin.rs
+++ b/software/deimos/src/calc/sin.rs
@@ -61,8 +61,14 @@ impl Sin {
     }
 
     /// Attach an output unit label (builder method).
+    ///
+    /// Panics if `unit` is not a recognized UCUM-subset string.
     pub fn with_output_unit(mut self: Box<Self>, unit: impl Into<String>) -> Box<Self> {
-        self.output_unit = Some(unit.into());
+        let unit = unit.into();
+        if let Err(e) = crate::units::parse_unit(&unit) {
+            panic!("Sin::with_output_unit got unparseable unit string {unit:?}: {e}");
+        }
+        self.output_unit = Some(unit);
         self
     }
 }
@@ -93,6 +99,7 @@ impl Calc for Sin {
         &mut self,
         ctx: ControllerCtx,
         _input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.output_index = output_range.clone().next().unwrap();
@@ -128,7 +135,7 @@ impl Calc for Sin {
         Ok(())
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![self.output_unit.clone()]
     }
 

--- a/software/deimos/src/calc/tc_ktype.rs
+++ b/software/deimos/src/calc/tc_ktype.rs
@@ -107,6 +107,7 @@ impl Calc for TcKtype {
         &mut self,
         _: ControllerCtx,
         input_indices: Vec<usize>,
+        _input_units: Vec<Option<String>>,
         output_range: Range<usize>,
     ) -> Result<(), String> {
         self.input_indices = input_indices;
@@ -162,7 +163,7 @@ impl Calc for TcKtype {
         Ok(())
     }
 
-    fn get_output_units(&self) -> Vec<Option<String>> {
+    fn get_output_units(&self, _input_units: &[Option<String>]) -> Vec<Option<String>> {
         vec![Some("K".to_owned())]
     }
 

--- a/software/deimos/src/controller/controller_state.rs
+++ b/software/deimos/src/controller/controller_state.rs
@@ -23,6 +23,15 @@ impl ControllerOperatingMetrics {
         Vec::<String>::from_iter(OUT.iter().map(|&x| x.to_owned()))
     }
 
+    /// Declared engineering units for `names_to_write`, parallel and same length.
+    /// The fixed-size array gives the same compile-time length guarantee as
+    /// `OUT` in `names_to_write`: bumping `num_to_write` without updating this
+    /// array fails to compile rather than silently mis-sizing the unit slice.
+    pub fn units_to_write(&self) -> Vec<Option<String>> {
+        const UNITS: [Option<&str>; ControllerOperatingMetrics::num_to_write()] = [Some("ns")];
+        UNITS.iter().map(|u| u.map(|s| s.to_string())).collect()
+    }
+
     pub const fn num_to_write() -> usize {
         1
     }
@@ -121,6 +130,19 @@ impl ControllerState {
     /// Get metric names to write to database
     pub fn get_names_to_write(&self) -> Vec<String> {
         self.names_to_write.clone()
+    }
+
+    /// Get declared engineering units for `get_names_to_write`, parallel and
+    /// same length. `None` for an entry means the unit is unknown.
+    pub fn get_units_to_write(&self) -> Vec<Option<String>> {
+        let mut units = Vec::with_capacity(self.names_to_write.len());
+        // Peripheral metrics, in BTreeMap iteration order (matches build_names_to_write).
+        for state in self.peripheral_state.values() {
+            units.extend(state.metric_units.iter().cloned());
+        }
+        // Controller metrics
+        units.extend(self.controller_metrics.units_to_write());
+        units
     }
 
     /// Get metric values to write to database

--- a/software/deimos/src/controller/mod.rs
+++ b/software/deimos/src/controller/mod.rs
@@ -840,8 +840,11 @@ impl Controller {
             let n_channels = n_metrics + n_io;
             let channel_values = vec![0.0; n_channels]; // Storage for dispatched values.
 
-            // Metric channels carry no declared unit; calc outputs use get_dispatch_units.
-            let mut channel_units: Vec<Option<String>> = vec![None; n_metrics];
+            // Metric channel units come per-peripheral from `Peripheral::metric_units`
+            // (default all-`None`), followed by controller-side metric units. Calc
+            // outputs come from `get_dispatch_units`.
+            let mut channel_units: Vec<Option<String>> = controller_state.get_units_to_write();
+            debug_assert_eq!(channel_units.len(), n_metrics);
             channel_units.extend(io_channel_units);
             self.ctx.channel_units = channel_units;
 

--- a/software/deimos/src/controller/peripheral_state.rs
+++ b/software/deimos/src/controller/peripheral_state.rs
@@ -5,6 +5,15 @@ use deimos_shared::{peripherals::PeripheralId, states::OperatingMetrics};
 
 use crate::socket::SocketAddr;
 
+/// Number of metric slots `write_metric_values` populates per peripheral.
+///
+/// `Peripheral::metric_names()` and `Peripheral::metric_units()` defaults must
+/// return exactly this many entries, and any override on a peripheral must
+/// match the same length until `write_metric_values` is generalized to drive
+/// from the metric name list. The invariant is asserted in
+/// `PeripheralState::new`.
+pub(crate) const PERIPHERAL_METRIC_COUNT: usize = 8;
+
 /// Peripheral control metrics
 #[derive(Default, Clone, Copy, Debug)]
 pub(crate) struct PeripheralMetrics {
@@ -82,6 +91,10 @@ pub(crate) struct PeripheralState {
     //
     /// Output channel names including peripheral name
     pub metric_full_names: Vec<String>,
+
+    /// Declared engineering units for each metric channel, parallel to
+    /// `metric_full_names`. Populated from `Peripheral::metric_units` at init.
+    pub metric_units: Vec<Option<String>>,
 }
 
 impl PeripheralState {
@@ -92,22 +105,33 @@ impl PeripheralState {
         p: &Box<dyn Peripheral>,
         ctx: &crate::controller::context::ControllerCtx,
     ) -> Self {
-        // Metric names are pretty manual
-        let mut mnames = Vec::new();
-        for orig in [
-            "cycle_time_ns",
-            "cycle_time_margin_ns",
-            "raw_timing_delta_ns",
-            "filtered_timing_delta_ns",
-            "requested_period_delta_ns",
-            "requested_phase_delta_ns",
-            "loss_of_contact_counter",
-            "cycle_lag_count",
-        ]
-        .iter()
-        {
-            mnames.push(format!("{name}.metrics.{orig}"))
-        }
+        // Metric names come from the peripheral; default impl returns the canonical
+        // timing/health set, but a peripheral may override.
+        let mnames = p
+            .metric_names()
+            .into_iter()
+            .map(|orig| format!("{name}.metrics.{orig}"))
+            .collect::<Vec<_>>();
+
+        let munits = p.metric_units();
+        assert_eq!(
+            munits.len(),
+            mnames.len(),
+            "Peripheral `{name}`: metric_units().len() != metric_names().len()"
+        );
+        // `write_metric_values` writes exactly `PERIPHERAL_METRIC_COUNT` slots
+        // by hardcoded index. A peripheral that overrides `metric_names()` to
+        // a different length would silently corrupt the metric stream or panic
+        // at write time. Lock the invariant here until `write_metric_values`
+        // is generalized to drive from `metric_names()`.
+        assert_eq!(
+            mnames.len(),
+            PERIPHERAL_METRIC_COUNT,
+            "Peripheral `{name}`: metric_names() returned {} entries, expected {PERIPHERAL_METRIC_COUNT}. \
+             Overriding metric_names() to a different length is currently unsupported \
+             until write_metric_values is generalized.",
+            mnames.len()
+        );
 
         let metrics = PeripheralMetrics::default();
         let acknowledged_configuration = false;
@@ -126,9 +150,15 @@ impl PeripheralState {
             metrics,
             has_received_packet: false,
             metric_full_names: mnames,
+            metric_units: munits,
         }
     }
 
+    /// Write the `PERIPHERAL_METRIC_COUNT` canonical timing/health metrics into
+    /// `out` by hardcoded positional index. The slot order matches the default
+    /// `Peripheral::metric_names()` list. `out.len()` must be at least
+    /// `PERIPHERAL_METRIC_COUNT`; the length-equality invariant with
+    /// `metric_names()` is enforced in `PeripheralState::new`.
     pub fn write_metric_values(&self, out: &mut [f64]) {
         out[0] = self.metrics.operating_metrics.cycle_time_ns as f64;
         out[1] = self.metrics.operating_metrics.cycle_time_margin_ns as f64;

--- a/software/deimos/src/lib.rs
+++ b/software/deimos/src/lib.rs
@@ -8,6 +8,7 @@ pub mod logging;
 pub mod math;
 pub mod peripheral;
 pub mod socket;
+pub mod units;
 
 pub use controller::{
     Controller, RunHandle, Snapshot,

--- a/software/deimos/src/peripheral/deimos_daq_rev7.rs
+++ b/software/deimos/src/peripheral/deimos_daq_rev7.rs
@@ -49,6 +49,22 @@ impl Peripheral for DeimosDaqRev7 {
         names
     }
 
+    fn metric_units(&self) -> Vec<Option<String>> {
+        // Parallel to the default `metric_names()` (8 entries). Channels whose unit
+        // is unambiguous from the suffix get `Some("ns")`; the trailing two are
+        // dimensionless cycle counts and stay `None`.
+        vec![
+            Some("ns".to_string()), // cycle_time_ns
+            Some("ns".to_string()), // cycle_time_margin_ns
+            Some("ns".to_string()), // raw_timing_delta_ns
+            Some("ns".to_string()), // filtered_timing_delta_ns
+            Some("ns".to_string()), // requested_period_delta_ns
+            Some("ns".to_string()), // requested_phase_delta_ns
+            None,                   // loss_of_contact_counter (dimensionless count)
+            None,                   // cycle_lag_count (dimensionless count)
+        ]
+    }
+
     fn output_names(&self) -> Vec<String> {
         let mut names = Vec::new();
 

--- a/software/deimos/src/peripheral/hootl.rs
+++ b/software/deimos/src/peripheral/hootl.rs
@@ -114,6 +114,14 @@ impl Peripheral for HootlPeripheral {
         self.inner.output_names()
     }
 
+    fn metric_names(&self) -> Vec<String> {
+        self.inner.metric_names()
+    }
+
+    fn metric_units(&self) -> Vec<Option<String>> {
+        self.inner.metric_units()
+    }
+
     fn operating_roundtrip_input_size(&self) -> usize {
         self.inner.operating_roundtrip_input_size()
     }

--- a/software/deimos/src/peripheral/mod.rs
+++ b/software/deimos/src/peripheral/mod.rs
@@ -88,8 +88,50 @@ pub trait Peripheral: Send + Sync + Debug {
     /// List of names of output fields
     fn output_names(&self) -> Vec<String>;
 
-    // fn input_units(&self) -> Vec<String>;
-    // fn output_units(&self) -> Vec<String>;
+    /// List of unprefixed metric channel names this peripheral publishes each cycle.
+    ///
+    /// Default: the canonical set of timing/health metrics every peripheral produces
+    /// (sourced from `OperatingMetrics` plus controller-side bookkeeping). Override
+    /// only if a peripheral diverges from this fixed set.
+    ///
+    /// The returned length is currently locked to
+    /// `controller::peripheral_state::PERIPHERAL_METRIC_COUNT` (8). An override
+    /// that returns a different length will trip the assertion in
+    /// `PeripheralState::new` until `write_metric_values` is generalized to
+    /// drive from this list.
+    fn metric_names(&self) -> Vec<String> {
+        [
+            "cycle_time_ns",
+            "cycle_time_margin_ns",
+            "raw_timing_delta_ns",
+            "filtered_timing_delta_ns",
+            "requested_period_delta_ns",
+            "requested_phase_delta_ns",
+            "loss_of_contact_counter",
+            "cycle_lag_count",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    /// Declared engineering units for each entry in `metric_names`, parallel and
+    /// same length. `None` means the unit is unknown or not applicable.
+    ///
+    /// Default: all `None` so peripherals that have not been audited preserve
+    /// today's behavior (no declared metric units). Override on a specific
+    /// peripheral to publish per-channel units (see `DeimosDaqRev7`).
+    ///
+    /// As with `metric_names`, the length is locked to
+    /// `controller::peripheral_state::PERIPHERAL_METRIC_COUNT` (8) until
+    /// `write_metric_values` is generalized.
+    fn metric_units(&self) -> Vec<Option<String>> {
+        vec![None; self.metric_names().len()]
+    }
+    // Peripheral input and output channels do not yet declare units at the
+    // trait surface; only metric channels do (above). Calc-graph unit checking
+    // applies between calcs, and metric units flow through
+    // `ControllerState::get_units_to_write`.
 
     /// Byte length of packet to send to the peripheral
     fn operating_roundtrip_input_size(&self) -> usize;

--- a/software/deimos/src/units/mod.rs
+++ b/software/deimos/src/units/mod.rs
@@ -1,0 +1,875 @@
+//! UCUM-subset unit parser and dimensional comparison.
+//!
+//! Calcs and peripherals declare engineering units as strings (e.g., `"K"`,
+//! `"m/s"`, `"kg.m/s^2"`). This module parses them into a `(Dimension, scale)`
+//! tuple so the orchestrator can validate that wires connecting calcs carry
+//! compatible units at controller-init time.
+//!
+//! The grammar is intentionally a bounded subset of UCUM:
+//!
+//! ```text
+//! unit       := factor ( ('*' | '.' | '/') factor )*
+//! factor     := base_unit ( '^' integer )?
+//! base_unit  := letter+ | '1'    // dimensionless = "1"
+//! ```
+//!
+//! Whitespace is ignored. Recognized base units and SI prefixes live on
+//! hard-coded allow-lists below — adding a new unit is a one-line edit.
+//!
+//! ## Why in-tree (vs. `uom`)
+//!
+//! `uom` and similar typed-units crates would force every unit-bearing trait
+//! method into a generic over `Quantity<...>`, which doesn't fit the existing
+//! `Vec<Option<String>>` carrier in `ControllerCtx`. The string-with-parser
+//! approach lets units stay opaque at the trait boundary while still catching
+//! the typo case (`RtdPt100`(K) → `Affine`(declared input Pa)) at init time.
+
+use std::fmt;
+
+/// Dimensional vector in SI base units. Each field is the integer exponent
+/// of that base dimension in the unit's expansion (e.g., `N` is mass=1,
+/// length=1, time=−2; everything else 0). Stored as `i8` because real-world
+/// physics doesn't go past `±127` and packing keeps `Dimension` cheap to
+/// compare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Dimension {
+    pub mass: i8,
+    pub length: i8,
+    pub time: i8,
+    pub current: i8,
+    pub temperature: i8,
+    pub amount: i8,
+    pub luminous: i8,
+}
+
+impl Dimension {
+    pub const fn new(
+        mass: i8,
+        length: i8,
+        time: i8,
+        current: i8,
+        temperature: i8,
+        amount: i8,
+        luminous: i8,
+    ) -> Self {
+        Self {
+            mass,
+            length,
+            time,
+            current,
+            temperature,
+            amount,
+            luminous,
+        }
+    }
+
+    /// Multiply two dimensions (i.e., add their exponents component-wise).
+    fn mul(self, other: Self) -> Self {
+        Self {
+            mass: self.mass + other.mass,
+            length: self.length + other.length,
+            time: self.time + other.time,
+            current: self.current + other.current,
+            temperature: self.temperature + other.temperature,
+            amount: self.amount + other.amount,
+            luminous: self.luminous + other.luminous,
+        }
+    }
+
+    /// Raise this dimension to an integer exponent (multiply each component).
+    fn pow(self, exp: i8) -> Self {
+        Self {
+            mass: self.mass * exp,
+            length: self.length * exp,
+            time: self.time * exp,
+            current: self.current * exp,
+            temperature: self.temperature * exp,
+            amount: self.amount * exp,
+            luminous: self.luminous * exp,
+        }
+    }
+
+    /// Render a short human-readable summary like `"temperature"` or
+    /// `"mass·length·time^-2"`. Used by error messages so the operator can
+    /// see *why* two units don't match without re-deriving it themselves.
+    pub fn describe(&self) -> String {
+        // Special cases for the common single-dimension units the operator
+        // is most likely to recognize at a glance.
+        if *self == Self::default() {
+            return "dimensionless".to_string();
+        }
+        let single = [
+            (self.mass, "mass"),
+            (self.length, "length"),
+            (self.time, "time"),
+            (self.current, "current"),
+            (self.temperature, "temperature"),
+            (self.amount, "amount"),
+            (self.luminous, "luminous"),
+        ];
+        let nonzero: Vec<_> = single.iter().filter(|(e, _)| *e != 0).collect();
+        if nonzero.len() == 1 && nonzero[0].0 == 1 {
+            return nonzero[0].1.to_string();
+        }
+        let mut parts = Vec::new();
+        for (exp, name) in single {
+            if exp == 0 {
+                continue;
+            } else if exp == 1 {
+                parts.push(name.to_string());
+            } else {
+                parts.push(format!("{name}^{exp}"));
+            }
+        }
+        parts.join("·")
+    }
+}
+
+/// A parsed unit string: its dimensional vector plus a multiplicative scale
+/// factor relative to the SI base for that dimension. For example, `kPa`
+/// parses to `dim = mass^1·length^-1·time^-2`, `scale = 1000.0`.
+///
+/// Temperature scales with offsets (`°C`, `°F`) cannot be represented
+/// as a single scale factor — they need an additive offset too. v1 only
+/// supports `K` and `°C`/`degC`, and treats `°C` as having a *different*
+/// `scale` than `K` so `units_equal` reports them as unequal. The
+/// orchestrator's pass-1 mismatch handler then attaches the K↔°C-specific
+/// `Affine` hint.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ParsedUnit {
+    pub dim: Dimension,
+    pub scale: f64,
+}
+
+/// Error returned by `parse_unit` when the input string isn't recognized.
+/// Always echoes the offending string verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub input: String,
+    pub reason: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "could not parse unit string {:?}: {}",
+            self.input, self.reason
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Hard-coded base units. Each entry is `(name, Dimension, scale)`.
+///
+/// `°C` and `degC` carry the temperature dimension with a *non-1* scale so
+/// equality with `K` fails — the orchestrator catches the K↔°C case as a
+/// mismatch and attaches a hint. We pick `1.0e9` as an arbitrary marker.
+///
+/// `1.0e9` numerically coincides with the `G` (giga) prefix scale on `Pa`,
+/// `Hz`, `W`, `J`, `N`, etc. That collision is harmless: temperature is the
+/// only dimension where this scale appears, no SI prefixes are allowed on
+/// `K`/`°C`/`degC` (see `prefix_allowed`), and `unit_mismatch_message`'s
+/// affine-hint path gates on temperature dimension before consulting the
+/// scale. So `(temperature=1, scale=1e9)` is a unique identifier for
+/// `°C`/`degC` even though `1e9` itself is not unique across all units.
+///
+/// Encoding a true offset would require a wider `ParsedUnit` and isn't
+/// needed for v1's fail-fast contract.
+const TEMP_C_SCALE: f64 = 1.0e9;
+
+/// Lookup result for a base unit (name, dimensional vector, scale relative
+/// to the SI base).
+struct BaseUnit {
+    name: &'static str,
+    dim: Dimension,
+    scale: f64,
+}
+
+const BASE_UNITS: &[BaseUnit] = &[
+    // Dimensionless
+    BaseUnit {
+        name: "1",
+        dim: Dimension::new(0, 0, 0, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    // SI base
+    BaseUnit {
+        name: "s",
+        dim: Dimension::new(0, 0, 1, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "m",
+        dim: Dimension::new(0, 1, 0, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "kg",
+        dim: Dimension::new(1, 0, 0, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "A",
+        dim: Dimension::new(0, 0, 0, 1, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "K",
+        dim: Dimension::new(0, 0, 0, 0, 1, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "mol",
+        dim: Dimension::new(0, 0, 0, 0, 0, 1, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        name: "cd",
+        dim: Dimension::new(0, 0, 0, 0, 0, 0, 1),
+        scale: 1.0,
+    },
+    // Derived SI
+    BaseUnit {
+        // Hz = 1/s
+        name: "Hz",
+        dim: Dimension::new(0, 0, -1, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // N = kg·m/s²
+        name: "N",
+        dim: Dimension::new(1, 1, -2, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // Pa = kg/(m·s²)
+        name: "Pa",
+        dim: Dimension::new(1, -1, -2, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // J = kg·m²/s²
+        name: "J",
+        dim: Dimension::new(1, 2, -2, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // W = kg·m²/s³
+        name: "W",
+        dim: Dimension::new(1, 2, -3, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // C (charge) = A·s. Note the disambiguation from °C below.
+        name: "C",
+        dim: Dimension::new(0, 0, 1, 1, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // V = kg·m²/(A·s³)
+        name: "V",
+        dim: Dimension::new(1, 2, -3, -1, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // ohm = kg·m²/(A²·s³)
+        name: "ohm",
+        dim: Dimension::new(1, 2, -3, -2, 0, 0, 0),
+        scale: 1.0,
+    },
+    BaseUnit {
+        // rad — dimensionless angle. `scale=1.0` means `rad` is equal to `1`
+        // under `units_equal` (which compares dim and scale), matching the
+        // physics (radians are dimensionless) and UCUM.
+        name: "rad",
+        dim: Dimension::new(0, 0, 0, 0, 0, 0, 0),
+        scale: 1.0,
+    },
+    // Temperature aliases for Celsius. Same dimension as K but a different
+    // scale, so equality with K fails and the orchestrator catches the
+    // mismatch.
+    BaseUnit {
+        name: "°C",
+        dim: Dimension::new(0, 0, 0, 0, 1, 0, 0),
+        scale: TEMP_C_SCALE,
+    },
+    BaseUnit {
+        name: "degC",
+        dim: Dimension::new(0, 0, 0, 0, 1, 0, 0),
+        scale: TEMP_C_SCALE,
+    },
+];
+
+/// Look up a base unit by its exact name. `None` if not recognized.
+fn lookup_base(name: &str) -> Option<&'static BaseUnit> {
+    BASE_UNITS.iter().find(|b| b.name == name)
+}
+
+/// SI-prefix allow-list per base unit. Each entry maps a prefix character
+/// (e.g., `'k'` for kilo) to its multiplier. The allow-list is per-base
+/// because some prefix+base combinations are ambiguous (`mK` looks like
+/// milli-Kelvin but `m` is also the meter base unit; to avoid the
+/// ambiguity, we reject all prefixes on `K`).
+//
+// Prefixes are also rejected on `m` (meter), `mol`, `cd`, `°C`,
+// `degC`, `rad`, and `1` for the same kind of ambiguity reason — `mm`
+// would be milli-meter but the parser sees `m` then `m` and we'd have to
+// special-case longest-match. Operators almost never type `mm` etc. into
+// a controller config; if they need to, they can write the SI base.
+//
+// Allow-listed bases for SI prefixes are the common pressure cases
+// (`kPa`, `MPa`, `mPa`) plus the few others where prefixes
+// are unambiguous and common in instrumentation (`mV`, `mA`, `kHz`, `MHz`,
+// `mN`, `kN`, `mW`, `kW`, `mJ`, `kJ`, `ms`, `ns`, `us`, `µs`, `kohm`, `Mohm`).
+struct PrefixSet {
+    base: &'static str,
+    allowed: &'static [(char, f64)],
+}
+
+const PREFIXES: &[PrefixSet] = &[
+    PrefixSet {
+        base: "Pa",
+        allowed: &[('m', 1e-3), ('k', 1e3), ('M', 1e6), ('G', 1e9)],
+    },
+    PrefixSet {
+        base: "Hz",
+        allowed: &[('m', 1e-3), ('k', 1e3), ('M', 1e6), ('G', 1e9)],
+    },
+    PrefixSet {
+        base: "V",
+        allowed: &[('m', 1e-3), ('u', 1e-6), ('µ', 1e-6), ('k', 1e3)],
+    },
+    PrefixSet {
+        base: "A",
+        allowed: &[('m', 1e-3), ('u', 1e-6), ('µ', 1e-6), ('k', 1e3)],
+    },
+    PrefixSet {
+        base: "N",
+        allowed: &[('m', 1e-3), ('k', 1e3), ('M', 1e6)],
+    },
+    PrefixSet {
+        base: "W",
+        allowed: &[('m', 1e-3), ('k', 1e3), ('M', 1e6)],
+    },
+    PrefixSet {
+        base: "J",
+        allowed: &[('m', 1e-3), ('k', 1e3), ('M', 1e6)],
+    },
+    PrefixSet {
+        base: "s",
+        allowed: &[('m', 1e-3), ('u', 1e-6), ('µ', 1e-6), ('n', 1e-9)],
+    },
+    PrefixSet {
+        base: "ohm",
+        allowed: &[('k', 1e3), ('M', 1e6)],
+    },
+    PrefixSet {
+        base: "C",
+        // Coulomb (charge) — small charges in mC, µC. Note: this is the
+        // *charge* `C`, not °C / degC (those have no prefixes by design).
+        allowed: &[('m', 1e-3), ('u', 1e-6), ('µ', 1e-6)],
+    },
+];
+
+/// If `name` looks like `<prefix><base>` where the prefix is on the base's
+/// allow-list, return `(scale, base)`. Else `None`. Tries every base on
+/// the prefix list and returns the *first* match — bases here are unique,
+/// so order doesn't matter for correctness.
+fn try_prefixed(name: &str) -> Option<(f64, &'static BaseUnit)> {
+    for set in PREFIXES {
+        let base = set.base;
+        if let Some(rest) = name.strip_suffix(base) {
+            // `rest` must be exactly one prefix char. We compare by char,
+            // not by byte, because `µ` is a multi-byte UTF-8 character.
+            let mut chars = rest.chars();
+            let prefix = chars.next()?;
+            if chars.next().is_some() {
+                continue;
+            }
+            for (allowed_prefix, scale) in set.allowed {
+                if *allowed_prefix == prefix {
+                    let base_unit = lookup_base(base)?;
+                    return Some((*scale, base_unit));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a single token (e.g., `"kPa"`, `"K"`, `"furlongs"`) to a
+/// `(dim, scale)` pair. Tries an exact-base lookup first, then a
+/// prefix+base lookup.
+fn resolve_token(token: &str, original: &str) -> Result<(Dimension, f64), ParseError> {
+    if let Some(base) = lookup_base(token) {
+        return Ok((base.dim, base.scale));
+    }
+    if let Some((prefix_scale, base)) = try_prefixed(token) {
+        return Ok((base.dim, base.scale * prefix_scale));
+    }
+    Err(ParseError {
+        input: original.to_string(),
+        reason: format!("unknown unit token {token:?}"),
+    })
+}
+
+/// Parse a unit string into its dimension and scale. Whitespace is
+/// stripped before parsing; the original is preserved for error messages.
+///
+/// Grammar (UCUM subset):
+///
+/// ```text
+/// unit       := factor ( ('*' | '.' | '/') factor )*
+/// factor     := token ( '^' integer )?
+/// token      := ascii letters or digits, e.g., kPa, m, mol, K, °C, degC, 1
+/// ```
+///
+/// Parens are not supported in v1 — every operator-typed unit string in
+/// the codebase today is flat. If we need them, this is the place to add
+/// them.
+pub fn parse_unit(input: &str) -> Result<ParsedUnit, ParseError> {
+    let stripped: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    if stripped.is_empty() {
+        return Err(ParseError {
+            input: input.to_string(),
+            reason: "empty unit string".to_string(),
+        });
+    }
+
+    // Walk through `stripped` accumulating tokens. Each token is preceded
+    // by an operator (`*`, `.`, or `/`); we treat the implicit leading
+    // operator as `*`. After each token we look for an optional `^integer`.
+    let mut dim = Dimension::default();
+    let mut scale = 1.0_f64;
+    let mut op = '*'; // current operator: applies to the next token
+    let mut chars = stripped.chars().peekable();
+
+    while chars.peek().is_some() {
+        // Read one token: contiguous letters / digits / `°` (for °C).
+        // Operators terminate the token.
+        let mut token = String::new();
+        while let Some(&c) = chars.peek() {
+            if c == '*' || c == '.' || c == '/' || c == '^' {
+                break;
+            }
+            token.push(c);
+            chars.next();
+        }
+        if token.is_empty() {
+            return Err(ParseError {
+                input: input.to_string(),
+                reason: format!("expected a unit token after operator '{op}'"),
+            });
+        }
+
+        // Optional `^integer` exponent.
+        let mut exp: i8 = 1;
+        if chars.peek() == Some(&'^') {
+            chars.next();
+            let mut exp_str = String::new();
+            // Allow a leading sign on the exponent (e.g., `m^-1`).
+            if matches!(chars.peek(), Some(&'-') | Some(&'+')) {
+                exp_str.push(chars.next().unwrap());
+            }
+            while let Some(&c) = chars.peek() {
+                if c.is_ascii_digit() {
+                    exp_str.push(c);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if exp_str.is_empty() || exp_str == "-" || exp_str == "+" {
+                return Err(ParseError {
+                    input: input.to_string(),
+                    reason: format!("expected integer exponent after '^' in token {token:?}"),
+                });
+            }
+            exp = exp_str.parse::<i8>().map_err(|_| ParseError {
+                input: input.to_string(),
+                reason: format!("exponent {exp_str:?} out of range for token {token:?}"),
+            })?;
+        }
+
+        // Resolve the token to a dimension+scale and apply op+exp.
+        let (token_dim, token_scale) = resolve_token(&token, input)?;
+        let signed_exp = match op {
+            '*' | '.' => exp,
+            '/' => -exp,
+            other => {
+                return Err(ParseError {
+                    input: input.to_string(),
+                    reason: format!("unexpected operator {other:?}"),
+                });
+            }
+        };
+        dim = dim.mul(token_dim.pow(signed_exp));
+        scale *= token_scale.powi(signed_exp as i32);
+
+        // Consume the next operator (if any).
+        match chars.peek() {
+            None => break,
+            Some(&c) if c == '*' || c == '.' || c == '/' => {
+                op = c;
+                chars.next();
+            }
+            Some(&c) => {
+                return Err(ParseError {
+                    input: input.to_string(),
+                    reason: format!("unexpected character {c:?} after token {token:?}"),
+                });
+            }
+        }
+    }
+
+    Ok(ParsedUnit { dim, scale })
+}
+
+/// Compare two unit strings for dimensional + scale equality. Returns
+/// `Ok(true)` only when both parse and produce the same `(dim, scale)`
+/// tuple. `Ok(false)` means they parse but differ. `Err` means one of the
+/// strings doesn't parse — the caller decides whether to treat that as a
+/// mismatch.
+///
+/// Note: a `None` declared unit on either side of a wire is *not* this
+/// function's concern; the orchestrator decides what to do with `None`.
+/// This function only operates on two parseable strings.
+pub fn units_equal(a: &str, b: &str) -> Result<bool, ParseError> {
+    let pa = parse_unit(a)?;
+    let pb = parse_unit(b)?;
+    Ok(pa.dim == pb.dim && pa.scale == pb.scale)
+}
+
+/// Sentinel string substituted into the mismatch message when one side of a
+/// wire declares no unit. Surfaces verbatim in the error so the operator can
+/// see *which* side was undeclared.
+pub const UNKNOWN_UNIT_DISPLAY: &str = "<unknown>";
+
+/// Build the mismatch-error message produced by orchestrator pass 1 when a
+/// declared input unit does not match the upstream-declared output unit.
+///
+/// The message contains every field needed to locate the bad wire: the
+/// destination calc kind, the destination input field name, the upstream
+/// source name, both unit strings (or `<unknown>` when `None`), and a
+/// human-readable dimensional reason. When both sides parse as temperature
+/// but their scales differ (the K↔°C case), a copy-pasteable `Affine`
+/// hint is appended so the operator can fix the wire without re-deriving
+/// the offset themselves.
+///
+/// Arguments:
+/// - `dest_calc_kind`: the receiving calc's [`Calc::kind`] (e.g., `"Affine"`)
+/// - `dest_input_field`: the receiving calc's input field name (e.g., `"x"`)
+/// - `source_name`: the upstream channel's full field name (e.g., `"rtd.K"`)
+/// - `dest_unit`: what the receiving calc declared (`get_input_units()`)
+/// - `source_unit`: what the upstream produces (peripheral output or upstream
+///   calc's `get_output_units()`)
+pub fn unit_mismatch_message(
+    dest_calc_kind: &str,
+    dest_input_field: &str,
+    source_name: &str,
+    dest_unit: Option<&str>,
+    source_unit: Option<&str>,
+) -> String {
+    let dest_str = dest_unit.unwrap_or(UNKNOWN_UNIT_DISPLAY);
+    let source_str = source_unit.unwrap_or(UNKNOWN_UNIT_DISPLAY);
+
+    // Try to parse both sides so the dimensional reason can be specific.
+    // Either side may be `<unknown>` (None) or unparseable; both cases fall
+    // back to a string-only reason.
+    let dest_parsed = dest_unit.and_then(|u| parse_unit(u).ok());
+    let source_parsed = source_unit.and_then(|u| parse_unit(u).ok());
+
+    let reason = match (&dest_parsed, &source_parsed) {
+        (Some(d), Some(s)) if d.dim == s.dim && d.scale != s.scale => {
+            format!(
+                "{0} dimension matches but scale differs ({1} vs {2})",
+                d.dim.describe(),
+                source_str,
+                dest_str,
+            )
+        }
+        (Some(d), Some(s)) => format!(
+            "different dimensions ({0} vs {1})",
+            s.dim.describe(),
+            d.dim.describe(),
+        ),
+        // One or both sides unparseable / unknown — echo the strings.
+        _ => format!("expected {dest_str}, got {source_str}"),
+    };
+
+    let mut msg = format!(
+        "Unit mismatch wiring `{source_name}` (declared {source_str}) into \
+         `{dest_calc_kind}` input `{dest_input_field}` (expected {dest_str}): {reason}"
+    );
+
+    // K↔°C affine hint: only when both parse, both are temperature, and the
+    // scales differ (one is K = 1.0, the other is °C/degC = TEMP_C_SCALE).
+    if let (Some(d), Some(s)) = (&dest_parsed, &source_parsed) {
+        let is_temp = d.dim.temperature == 1
+            && d.dim.mass == 0
+            && d.dim.length == 0
+            && d.dim.time == 0
+            && d.dim.current == 0
+            && d.dim.amount == 0
+            && d.dim.luminous == 0;
+        if is_temp && d.dim == s.dim && d.scale != s.scale {
+            // Determine direction by comparing scales against the K base
+            // (scale 1.0) vs. °C marker (TEMP_C_SCALE).
+            let source_is_kelvin = s.scale == 1.0;
+            let dest_is_kelvin = d.scale == 1.0;
+            let hint = if source_is_kelvin && !dest_is_kelvin {
+                // K → °C: subtract 273.15 to convert.
+                "K and °C are dimensionally compatible but require an offset \
+                 conversion; insert an Affine(scale=1.0, offset=-273.15) \
+                 between source and dest"
+            } else if !source_is_kelvin && dest_is_kelvin {
+                // °C → K: add 273.15.
+                "°C and K are dimensionally compatible but require an offset \
+                 conversion; insert an Affine(scale=1.0, offset=273.15) \
+                 between source and dest"
+            } else {
+                // Both °C-ish or both K-ish: shouldn't happen given scale check above.
+                ""
+            };
+            if !hint.is_empty() {
+                msg.push_str(" — ");
+                msg.push_str(hint);
+            }
+        }
+    }
+
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_base() {
+        let p = parse_unit("K").unwrap();
+        assert_eq!(p.dim.temperature, 1);
+        assert_eq!(p.scale, 1.0);
+    }
+
+    #[test]
+    fn parses_dimensionless() {
+        let p = parse_unit("1").unwrap();
+        assert_eq!(p.dim, Dimension::default());
+        assert_eq!(p.scale, 1.0);
+    }
+
+    #[test]
+    fn newton_round_trip() {
+        // N == kg·m/s^2
+        assert!(units_equal("N", "kg.m/s^2").unwrap());
+        assert!(units_equal("N", "kg*m/s^2").unwrap());
+        let p = parse_unit("kg.m/s^2").unwrap();
+        assert_eq!(p.dim.mass, 1);
+        assert_eq!(p.dim.length, 1);
+        assert_eq!(p.dim.time, -2);
+        assert_eq!(p.scale, 1.0);
+    }
+
+    #[test]
+    fn pascal_round_trip() {
+        // Pa == kg/(m·s^2) which we have to write as kg/m/s^2 (no parens in v1)
+        assert!(units_equal("Pa", "kg/m/s^2").unwrap());
+    }
+
+    #[test]
+    fn kpa_is_1000_pa() {
+        let kpa = parse_unit("kPa").unwrap();
+        let pa = parse_unit("Pa").unwrap();
+        assert_eq!(kpa.dim, pa.dim);
+        assert_eq!(kpa.scale, 1000.0);
+    }
+
+    #[test]
+    fn kpa_neq_pa() {
+        // Same dimension, different scale.
+        assert!(!units_equal("kPa", "Pa").unwrap());
+    }
+
+    #[test]
+    fn mpa_is_milli_pascal() {
+        // `mPa` means millipascal under our prefix allow-list, NOT meter-pascal.
+        let mpa = parse_unit("mPa").unwrap();
+        let pa = parse_unit("Pa").unwrap();
+        assert_eq!(mpa.dim, pa.dim);
+        assert_eq!(mpa.scale, 1e-3);
+    }
+
+    #[test]
+    fn megapascal_is_1e6_pa() {
+        let mega = parse_unit("MPa").unwrap();
+        assert_eq!(mega.scale, 1e6);
+    }
+
+    #[test]
+    fn unknown_unit_echoes_input() {
+        let err = parse_unit("furlongs").unwrap_err();
+        assert_eq!(err.input, "furlongs");
+        // The display impl quotes the input verbatim too.
+        assert!(err.to_string().contains("furlongs"));
+    }
+
+    #[test]
+    fn unknown_unit_in_compound_echoes_input() {
+        let err = parse_unit("furlongs/fortnight").unwrap_err();
+        assert_eq!(err.input, "furlongs/fortnight");
+        assert!(err.to_string().contains("furlongs/fortnight"));
+    }
+
+    #[test]
+    fn mk_is_ambiguous_and_rejected() {
+        // `mK` would be milli-Kelvin if K were on the prefix allow-list, but
+        // it isn't (we reject prefixes on K to keep it unambiguous with `m`
+        // the base meter unit). So `mK` parses as the unknown token `mK`.
+        let err = parse_unit("mK").unwrap_err();
+        assert_eq!(err.input, "mK");
+    }
+
+    #[test]
+    fn temperature_units_reject_si_prefixes() {
+        // The TEMP_C_SCALE = 1.0e9 marker is only safe because no SI prefix is
+        // allowed on K/°C/degC. If any of these started parsing successfully
+        // we'd have a scale collision (e.g., a hypothetical kK at scale=1e3
+        // would still be temperature dimension and could mask K vs °C handling).
+        // Lock the rejection in.
+        assert!(parse_unit("mK").is_err());
+        assert!(parse_unit("kK").is_err());
+        assert!(parse_unit("m°C").is_err());
+    }
+
+    #[test]
+    fn celsius_and_kelvin_have_different_scales() {
+        // K and °C are dimensionally compatible but treated as unequal so
+        // the orchestrator can attach the K↔°C affine hint.
+        let k = parse_unit("K").unwrap();
+        let c = parse_unit("°C").unwrap();
+        assert_eq!(k.dim, c.dim);
+        assert_ne!(k.scale, c.scale);
+        assert!(!units_equal("K", "°C").unwrap());
+        assert!(!units_equal("K", "degC").unwrap());
+    }
+
+    #[test]
+    fn celsius_aliases_match_each_other() {
+        assert!(units_equal("°C", "degC").unwrap());
+    }
+
+    #[test]
+    fn whitespace_is_ignored() {
+        assert!(units_equal("kg.m / s^2", "N").unwrap());
+        assert!(units_equal("  K  ", "K").unwrap());
+    }
+
+    #[test]
+    fn empty_string_is_error() {
+        let err = parse_unit("").unwrap_err();
+        assert_eq!(err.input, "");
+    }
+
+    #[test]
+    fn negative_exponent() {
+        // Hz == s^-1 — both should produce dim time = -1, scale = 1.
+        assert!(units_equal("Hz", "s^-1").unwrap());
+    }
+
+    #[test]
+    fn dot_and_star_are_equivalent() {
+        assert!(units_equal("kg.m", "kg*m").unwrap());
+    }
+
+    #[test]
+    fn double_quotient_is_left_associative() {
+        // `kg/m/s^2` == `kg/(m·s^2)` == Pa under left-to-right reading.
+        // Each `/` flips the sign of the *next* token's exponent only,
+        // matching UCUM's left-to-right reading.
+        let p = parse_unit("kg/m/s^2").unwrap();
+        assert_eq!(p.dim.mass, 1);
+        assert_eq!(p.dim.length, -1);
+        assert_eq!(p.dim.time, -2);
+    }
+
+    #[test]
+    fn rad_is_dimensionless() {
+        // Radians are dimensionless in physics; equality with `1` confirms it.
+        assert!(units_equal("rad", "1").unwrap());
+    }
+
+    #[test]
+    fn coulomb_charge_is_a_times_s() {
+        assert!(units_equal("C", "A.s").unwrap());
+    }
+
+    #[test]
+    fn micro_volt_unicode_and_ascii_match() {
+        let ascii = parse_unit("uV").unwrap();
+        let unicode = parse_unit("µV").unwrap();
+        assert_eq!(ascii, unicode);
+    }
+
+    #[test]
+    fn mismatch_message_includes_required_fields() {
+        // Pa upstream → K downstream: different dimensions. The message must
+        // name the source, dest calc kind, dest input field, both unit
+        // strings, and a dimensional reason.
+        let msg = unit_mismatch_message("Affine", "x", "rtd.K", Some("K"), Some("Pa"));
+        assert!(msg.contains("Affine"), "missing dest calc kind: {msg}");
+        assert!(msg.contains("`x`"), "missing dest input field: {msg}");
+        assert!(msg.contains("rtd.K"), "missing source name: {msg}");
+        assert!(msg.contains("K"), "missing dest unit: {msg}");
+        assert!(msg.contains("Pa"), "missing source unit: {msg}");
+        // Dimensional reason — the dimensions differ. Require the dimension
+        // words from `Dimension::describe()` (here `temperature` for K and
+        // `mass`/`length`/`time` from Pa's decomposition) so a regression
+        // that drops `describe()` and falls back to the unit-strings-only
+        // path would fail this test. The "different dimensions" wrapper
+        // alone is not enough — it doesn't witness that `describe()` ran.
+        assert!(
+            msg.contains("temperature"),
+            "missing dest dimension name: {msg}"
+        );
+        assert!(
+            msg.contains("mass") && msg.contains("length") && msg.contains("time"),
+            "missing source dimension names: {msg}"
+        );
+    }
+
+    #[test]
+    fn mismatch_message_unknown_side_uses_sentinel() {
+        let msg = unit_mismatch_message("Affine", "x", "rtd.unknown", Some("K"), None);
+        assert!(msg.contains(UNKNOWN_UNIT_DISPLAY));
+    }
+
+    #[test]
+    fn k_to_celsius_message_has_affine_hint() {
+        // Source K → dest °C: subtract 273.15.
+        let msg = unit_mismatch_message("Affine", "x", "rtd.K", Some("°C"), Some("K"));
+        assert!(msg.contains("K"), "missing K: {msg}");
+        assert!(msg.contains("°C"), "missing °C: {msg}");
+        assert!(msg.contains("offset=-273.15"), "missing affine hint: {msg}");
+    }
+
+    #[test]
+    fn celsius_to_k_message_has_reverse_affine_hint() {
+        // Source °C → dest K: add 273.15.
+        let msg = unit_mismatch_message("Affine", "x", "src.celsius", Some("K"), Some("°C"));
+        assert!(msg.contains("offset=273.15"), "missing affine hint: {msg}");
+        // Make sure we got the positive offset, not the negative one.
+        assert!(!msg.contains("offset=-273.15"));
+    }
+
+    #[test]
+    fn unparseable_dest_unit_falls_back_to_string_reason() {
+        // Dest declares `furlongs` (unparseable). The reason should fall
+        // back to echoing the strings rather than blowing up.
+        let msg = unit_mismatch_message("Affine", "x", "src.K", Some("furlongs"), Some("K"));
+        assert!(msg.contains("furlongs"));
+        assert!(msg.contains("K"));
+    }
+}


### PR DESCRIPTION
Validate physical-unit compatibility when the calc graph is initialized, so mismatched connections fail fast at init rather than producing silently wrong results at runtime. Adds a units module (SI parsing + dimensional analysis) and threads unit metadata through calc nodes, peripherals, and controller state.