### PR TITLE
Remove cross-crate doc include_str

### DIFF
--- a/.github/workflows/test-deimos_console.yml
+++ b/.github/workflows/test-deimos_console.yml
@@ -21,13 +21,6 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
-    - name: Formatting Lint
-      run: cargo fmt --check
-    - name: Structural Lint
-      run: cargo clippy --all-features
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
     - name: Run tests
       run: |
-        cargo test -p deimos
-        cargo check --workspace --all-features --examples
+        cargo test -p deimos_console --all-features

--- a/.github/workflows/test-deimos_console.yml
+++ b/.github/workflows/test-deimos_console.yml
@@ -1,4 +1,4 @@
-name: test-rust
+name: test-deimos_console
 
 on:
   pull_request:

--- a/.github/workflows/test-deimos_numerics.yml
+++ b/.github/workflows/test-deimos_numerics.yml
@@ -1,4 +1,4 @@
-name: test-rust-numerics
+name: test-deimos_numerics
 
 on:
   pull_request:

--- a/.github/workflows/test-deimos_shared.yml
+++ b/.github/workflows/test-deimos_shared.yml
@@ -21,13 +21,6 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
-    - name: Formatting Lint
-      run: cargo fmt --check
-    - name: Structural Lint
-      run: cargo clippy --all-features
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
     - name: Run tests
       run: |
-        cargo test -p deimos
-        cargo check --workspace --all-features --examples
+        cargo test -p deimos_shared --all-features

--- a/.github/workflows/test-deimos_shared.yml
+++ b/.github/workflows/test-deimos_shared.yml
@@ -1,4 +1,4 @@
-name: test-rust
+name: test-deimos_shared
 
 on:
   pull_request:

--- a/software/deimos/src/peripheral/deimos_daq_rev7.rs
+++ b/software/deimos/src/peripheral/deimos_daq_rev7.rs
@@ -133,9 +133,9 @@ impl CalRecord {
 }
 
 /// Software interface for a Deimos DAQ rev7 peripheral.
-#[doc = include_str!(
-    "../../../deimos_shared/src/peripherals/deimos_daq_rev7/modbus_register_map.md"
-)]
+///
+/// The complete Modbus/TCP register map is documented in
+/// [`deimos_shared::peripherals::deimos_daq_rev7::modbus`].
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct DeimosDaqRev7 {


### PR DESCRIPTION
* Remove doc include_str that passes rustdoc locally but fails tarball verification during publish.
* Split rust test actions into multiple jobs to reduce build time